### PR TITLE
Add React to content scripts

### DIFF
--- a/config/webpack.static.config.js
+++ b/config/webpack.static.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack')
 const paths = require('./paths')
 const createWebpackConfig = require('./webpack.config')
 
@@ -11,14 +12,12 @@ module.exports = function webpackConfig(entry, filename, webpackEnv) {
       filename,
     },
     optimization: {
-      minimize: true,
-      splitChunks: {
-        chunks: 'initial',
-        name: false,
-      },
       runtimeChunk: false,
+      splitChunks: { chunks: 'initial' },
     },
     // remove plugins to avoid html injection
-    plugins: [],
+    plugins: [
+      new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+    ],
   })
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "serve": "serve",
     "start": "node scripts/watch.js",
-    "build": "PUBLIC_URL=./ node scripts/build.js && npm run append:sw && npm run append:sm",
+    "build": "PUBLIC_URL=./ node scripts/build.js && npm run append:sw",
     "append:sw": "cra-append-sw --mode replace --skip-compile ./public/service-worker.js",
     "append:sm": "node scripts/modify-source-maps.js",
     "test": "node scripts/test.js --env=jsdom",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "serve": "serve",
     "start": "node scripts/watch.js",
-    "build": "PUBLIC_URL=./ node scripts/build.js && npm run append:sw",
+    "build": "PUBLIC_URL=./ node scripts/build.js && npm run append:sw && npm run append:sm",
     "append:sw": "cra-append-sw --mode replace --skip-compile ./public/service-worker.js",
     "append:sm": "node scripts/modify-source-maps.js",
     "test": "node scripts/test.js --env=jsdom",

--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,7 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <div id="root"></div>
+    <div id="mujo-extension"></div>
     <script nonce>
       navigator.serviceWorker.register('service-worker.js')
     </script>

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import * as utilStyles from './styles/utils'
 import { track } from './tracker'
 
 styleGuide.push(utilStyles)
+css.global('body, html', { margin: 0 })
 
 const bodyBackgrounds = {
   outerSpace: `radial-gradient(ellipse at center, ${

--- a/src/background/inject.js
+++ b/src/background/inject.js
@@ -1,4 +1,4 @@
-import { tabs } from '../lib/extension'
+import { tabs, runtime } from '../lib/extension'
 
 const BLACK_LIST = ['about:blank', 'chrome']
 
@@ -10,5 +10,8 @@ export const injectScript = tab => {
   if (isBlackListed || isSubFrame) {
     return
   }
-  tabs.executeScript(tab.tabId, { file: 'content.js' })
+  tabs.executeScript(tab.tabId, { file: 'content.js' }, results => {
+    console.log(results)
+    console.log(runtime.lastError)
+  })
 }

--- a/src/components/content-app/index.js
+++ b/src/components/content-app/index.js
@@ -1,0 +1,48 @@
+import { styleGuide } from '@jcblw/box'
+import React, { useState } from 'react'
+import { useTheme } from '../../hooks/use-theme'
+import { shortURL } from '../../lib/url'
+import * as utilStyles from '../../styles/utils'
+import { BodyL } from '../fonts'
+import { Modal } from '../modal'
+import { Player } from '../player'
+import { Time } from '../time'
+
+styleGuide.push(utilStyles)
+
+const ContentApp = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const { foreground } = useTheme()
+  // TODO this is mock data
+  const label = shortURL(window.location.href)
+  const time = 23432.3
+  const percent = 41
+  return (
+    <Modal isOpen css={{ minWidth: '30vw' }} textAlign="center">
+      <Player
+        isOpen={isOpen}
+        width={64}
+        height={64}
+        onFinish={() => {
+          setIsOpen(false)
+        }}
+        onClick={() => {
+          setIsOpen(true)
+        }}
+      />
+      <BodyL
+        marginTop="s"
+        marginBottom="s"
+        css={{ maxWidth: '30vw' }}
+      >
+        The site {label} was actively viewed for{' '}
+        <Time Component="span" color={foreground}>
+          {time}
+        </Time>{' '}
+        since your last break. That is {percent}% of your web viewing.
+      </BodyL>
+    </Modal>
+  )
+}
+
+export default ContentApp

--- a/src/components/fonts/styles.js
+++ b/src/components/fonts/styles.js
@@ -1,6 +1,6 @@
 import { css } from 'glamor'
 
-css.global('*', {
+css.global('#mujo-extension *, .mujo-modal *', {
   fontFamily: "'IBM Plex Sans', sans-serif",
   '-webkit-font-smoothing': 'antialiased',
   '-moz-osx-font-smoothing': 'grayscale',

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -2,12 +2,11 @@ import { styleGuide } from '@jcblw/box'
 import { propsToStyles } from '@jcblw/box/dist/lib/helpers'
 import { removeKeys } from '@jcblw/box/dist/lib/remove-keys'
 import { cssToStyle } from '@jcblw/box/dist/styles/helpers'
+import { css as glamor } from 'glamor'
 import React from 'react'
 import ReactModal from 'react-modal'
 import { useTheme } from '../../hooks/use-theme'
-import { colors, rgba } from '../../styles/colors'
-
-ReactModal.setAppElement('#root')
+import { rgba, getColor } from '../../styles/colors'
 
 const overlay = cssToStyle({
   position: 'fixed',
@@ -26,20 +25,23 @@ const modelContent = cssToStyle({
   overflow: 'scroll',
 })
 
-const overlayColor = color => rgba(colors[color], 0.3)
 const getPropClasses = propsToStyles(styleGuide)
-const getOverlayClass = color =>
-  cssToStyle(overlay, { background: overlayColor(color) }).toString()
-const getModalContent = ({ background, color }) =>
-  cssToStyle(
+const toString = fn => (...args) => `${fn(...args)}`
+const getOverlayClass = toString(c =>
+  glamor({ backgroundColor: rgba(c, 0.7) }, overlay)
+)
+const getModalContent = toString(({ background, color }) =>
+  glamor(
     {
-      background: colors[background],
-      color: colors[color],
+      background: getColor(background),
+      color: getColor(color),
     },
     modelContent
-  ).toString()
+  )
+)
 
 export const Modal = props => {
+  ReactModal.setAppElement('#mujo-extension')
   const theme = useTheme()
   const { css } = props
   const results = getPropClasses(

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -55,12 +55,15 @@ export const Modal = props => {
   )
   return (
     <ReactModal
+      data-mujo
       shouldCloseOnOverlayClick={true}
       className={`${results.styles.join(' ')} ${getModalContent({
         background: theme.background,
         color: theme.foreground,
       })}`}
-      overlayClassName={getOverlayClass(theme.backgroundSecondary)}
+      overlayClassName={`mujo-modal ${getOverlayClass(
+        theme.backgroundSecondary
+      )}`}
       {...otherProps}
     />
   )

--- a/src/content.js
+++ b/src/content.js
@@ -1,3 +1,7 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import ContentApp from './components/content-app'
+
 import {
   onVisibilityChange,
   onViewingStart,
@@ -10,4 +14,15 @@ window.document.addEventListener(
   onVisibilityChange,
   true
 )
+
 window.addEventListener('beforeunload', onViewingEnd)
+
+if (process.env.CONTENT_MODAL) {
+  // React app in content script
+  const el = document.createElement('div')
+  el.id = 'mujo-extension'
+
+  document.body.appendChild(el)
+
+  ReactDOM.render(<ContentApp />, el)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,4 +14,4 @@ const Mujō = () => (
   </ErrorBox>
 )
 
-ReactDOM.render(<Mujō />, document.getElementById('root'))
+ReactDOM.render(<Mujō />, document.getElementById('mujo-extension'))

--- a/src/lib/extension.js
+++ b/src/lib/extension.js
@@ -12,4 +12,10 @@ export const onMessage = (...args) => {
   chrome.runtime.onMessage.addListener(...args)
 }
 
-export const { alarms, notifications, tabs, webNavigation } = chrome
+export const {
+  alarms,
+  notifications,
+  tabs,
+  webNavigation,
+  runtime,
+} = chrome

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -7,12 +7,15 @@ export const colors = {
   transparent: 'transparent',
 }
 
+export const getColor = colorName => colors[colorName]
+
 const toRGB = hex => {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
   return result ? result.slice(1, 4).map(n => parseInt(n, 16)) : null
 }
 
-export const rgba = (hex, alpha) => {
+export const rgba = (color, alpha) => {
+  const hex = /^#/.test(color) ? color : getColor(color)
   const rgb = toRGB(hex)
   return `rgba(${rgb.join(',')},${alpha})`
 }

--- a/src/styles/utils.js
+++ b/src/styles/utils.js
@@ -8,8 +8,6 @@ const makeStyles = (key, values) => {
   return keys.reduce(reducer, {})
 }
 
-css.global('body, html', { margin: 0 })
-
 const spacingValues = { zero: 0 }
 
 // Spacing Addons


### PR DESCRIPTION
Now that we bundle content scripts with webpack now we have the ability to reuse all our react code. Threw together a POC of a modal running in the content script.

This will make 
https://www.notion.so/jjcblw/Screen-Time-Break-timer-modal-1dc5c56559c0438489cbafa84bf6978c
A lot easier task then it is estimated. There is still some concerns about the size of the bundle even though it is a local file.

<img width="1428" alt="Screen Shot 2019-06-24 at 3 25 22 PM" src="https://user-images.githubusercontent.com/578259/60056533-113d4680-9696-11e9-83ad-1950a02f77cc.png">

```shell
# latest build
build:index.js       Starting build... - 62ms
build:index.js       Compiled successfully. - 12309ms
build:index.js       asset-manifest.json: 453 B - 12311ms
build:index.js       index.html: 727 B - 12312ms
build:index.js       static/js/2.4cbed6a8.chunk.js: 203.91 KB - 12312ms
build:index.js       static/js/2.4cbed6a8.chunk.js.map: 711.51 KB - 12312ms
build:index.js       static/js/main.72135dd8.chunk.js: 26.88 KB - 12312ms
build:index.js       static/js/main.72135dd8.chunk.js.map: 92.38 KB - 12313ms
build:index.js       static/js/runtime~main.9547a125.js: 1.47 KB - 12313ms
build:index.js       static/js/runtime~main.9547a125.js.map: 7.82 KB - 12313ms
build:background.js  Starting build... - 12313ms
build:background.js  Compiled successfully. - 13283ms
build:background.js  background.js: 2.51 KB - 13283ms
build:background.js  background.js.map: 13.43 KB - 13284ms
build:content.js     Starting build... - 13284ms
build:content.js     Compiled successfully. - 17399ms
build:content.js     content.js: 192.67 KB - 17400ms
build:content.js     content.js.map: 624.17 KB - 17400ms
```
