### PR TITLE
Feature flag Screen Time

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import { Player } from './components/player'
 import { ScreenTime } from './components/screen-time'
 import { ToolTip } from './components/tool-tip'
 import { TopSites } from './components/top-sites'
+import { SCREEN_TIME_FEATURE } from './constants'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
 import { colors } from './styles/colors'
@@ -103,7 +104,7 @@ const App = () => {
             </ToolTip>
           </Box>
           <Box flex="1" />
-          {showTopSites ? (
+          {!SCREEN_TIME_FEATURE || showTopSites ? (
             <TopSites
               topSites={topSites}
               updateSitesUsed={updateSitesUsed}
@@ -133,21 +134,25 @@ const App = () => {
                 design={theme.buttonStyle}
                 onClick={toggleHandle(setAlarmEnabled, alarmEnabled)}
                 alt={REMINDER_ALT}
-                marginRight="m"
+                marginRight={SCREEN_TIME_FEATURE ? 'm' : 'zero'}
               >
                 Turn reminders {alarmEnabled ? 'off' : 'on'}
               </Button>
-              <Button
-                whiteSpace="nowrap"
-                design={theme.buttonStyle}
-                onClick={toggleHandle(
-                  updateShowTopSites,
-                  showTopSites
-                )}
-                alt="Toggle the view of the top sites section of this extension"
-              >
-                {showTopSites ? 'Show screen time' : 'Show top sites'}
-              </Button>
+              {SCREEN_TIME_FEATURE && (
+                <Button
+                  whiteSpace="nowrap"
+                  design={theme.buttonStyle}
+                  onClick={toggleHandle(
+                    updateShowTopSites,
+                    showTopSites
+                  )}
+                  alt="Toggle view between screen time and top sites"
+                >
+                  {showTopSites
+                    ? 'Show screen time'
+                    : 'Show top sites'}
+                </Button>
+              )}
             </Box>
           </Box>
         </>

--- a/src/background/inject.js
+++ b/src/background/inject.js
@@ -1,3 +1,4 @@
+import { SCREEN_TIME_FEATURE } from '../constants'
 import { tabs, runtime } from '../lib/extension'
 
 const BLACK_LIST = ['about:blank', 'chrome']
@@ -7,7 +8,7 @@ export const injectScript = tab => {
     tab.url.startsWith(url)
   )
   const isSubFrame = tab.transitionType === '"auto_subframe"'
-  if (isBlackListed || isSubFrame) {
+  if (isBlackListed || isSubFrame || !SCREEN_TIME_FEATURE) {
     return
   }
   tabs.executeScript(tab.tabId, { file: 'content.js' }, results => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,4 +20,4 @@ export const GET_STORAGE = 'GET_STORAGE'
 export const SET_STORAGE = 'SET_STORAGE'
 
 // Feature Flags
-export const SCREEN_TIME_FEATURE = true
+export const SCREEN_TIME_FEATURE = false

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,3 +18,6 @@ export const PAGE_VIEWING_TIME = 'Page Viewing Time'
 // Getter, Setters for storage
 export const GET_STORAGE = 'GET_STORAGE'
 export const SET_STORAGE = 'SET_STORAGE'
+
+// Feature Flags
+export const SCREEN_TIME_FEATURE = true


### PR DESCRIPTION
This PR create a feature flag for the Screen Time feature. That way we can make another release with all the improvements I have done over the past couple weeks.

@itsjustmath I want you to play around with Screen Time so to create a build locally with do the followings.

Edit the [feature flag](https://github.com/jcblw/Mujo-extension/compare/patch/feature-flag-screen-time?expand=1#diff-a7748843fbda5167d065231e3a2e7a1fR23) to be true. 

```shell
npm run build # you will need to install first
```

then [install into Chrome](https://github.com/jcblw/Mujo-extension#installing-into-chrome)

or install this ZIP

[Mujō-1.0.0.zip](https://github.com/jcblw/Mujo-extension/files/3330644/Mujo-1.0.0.zip)
