### PR TITLE
Fix percent error on small amounts of time data

### DIFF
--- a/src/components/graph/attributes.test.js
+++ b/src/components/graph/attributes.test.js
@@ -1,0 +1,78 @@
+import {
+  angleToRadian,
+  getCirclePoint,
+  angleOfPercent,
+  getPathAttributes,
+  getLabelAttributes,
+} from './attributes'
+
+test('angleToRadian will convert and 360 degree angle to a radian', () => {
+  expect(angleToRadian(180)).toBe(3.141592653589793)
+})
+
+test('getCirclePoint should return a function', () => {
+  expect(typeof getCirclePoint([0, 0])).toBe('function')
+})
+
+test('getCirclePoint return should return a x y coord for the circle', () => {
+  expect(getCirclePoint([0, 0], 1)(180)).toEqual({
+    x: -1,
+    y: 1.2246467991473532e-16,
+  })
+})
+
+test('angleOfPercent should give you a 360° angle percent', () => {
+  expect(angleOfPercent(0.5)).toBe(180)
+})
+
+test('getPathAttributes should generate path data with an arc', () => {
+  const getInnerPoint = jest
+    .fn()
+    .mockReturnValueOnce({ x: 0, y: 0 })
+    .mockReturnValueOnce({ x: 1, y: 1 })
+  const angles = [1, 2]
+  const radius = 30
+  expect(
+    getPathAttributes({ angles, getInnerPoint, radius })
+  ).toEqual({ d: 'M 0 0 A 30 30 0 0 1 1 1' })
+})
+
+test('getPathAttributes should generate path data and flip arc flags', () => {
+  const getInnerPoint = jest
+    .fn()
+    .mockReturnValueOnce({ x: 0, y: 0 })
+    .mockReturnValueOnce({ x: 1, y: 1 })
+  const angles = [500, 1000]
+  const radius = 30
+  expect(
+    getPathAttributes({ angles, getInnerPoint, radius })
+  ).toEqual({ d: 'M 0 0 A 30 30 0 1 1 1 1' })
+})
+
+test(`
+  getLabelAttributes have a x, y, children, textAnchor,
+  and alignmentBaseline properties
+`, () => {
+  const label = 'foo'
+  const angles = [0, 1]
+  const center = [0, 0]
+  const getOuterPoint = jest
+    .fn()
+    .mockReturnValueOnce({ x: 10, y: 10 })
+  const rotateGraph = 0
+  expect(
+    getLabelAttributes({
+      angles,
+      getOuterPoint,
+      rotateGraph,
+      center,
+      label,
+    })
+  ).toEqual({
+    children: label,
+    x: 10,
+    y: 10,
+    textAnchor: 'start',
+    alignmentBaseline: 'hanging',
+  })
+})

--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -29,8 +29,7 @@ exports[`ScreenTime should match snapshot 1`] = `
     >
       <path
         className="css-dw3c54 css-c5mv14"
-        d="M 400 137.5 A 100 100 0 0 1 254.78696143925166 226.69518565541688
-  "
+        d="M 400 137.5 A 100 100 0 0 1 254.78696143925166 226.69518565541688"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -39,8 +38,7 @@ exports[`ScreenTime should match snapshot 1`] = `
       />
       <path
         className="css-dw3c54 css-c5mv14"
-        d="M 231.95291274890502 210.77751303532256 A 100 100 0 0 1 243.56355381395008 54.947425588967306
-  "
+        d="M 231.95291274890502 210.77751303532256 A 100 100 0 0 1 243.56355381395008 54.947425588967306"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -49,8 +47,7 @@ exports[`ScreenTime should match snapshot 1`] = `
       />
       <path
         className="css-dw3c54 css-c5mv14"
-        d="M 268.50437935300914 42.58937951914527 A 100 100 0 0 1 383.37096071317376 82.27968752567193
-  "
+        d="M 268.50437935300914 42.58937951914527 A 100 100 0 0 1 383.37096071317376 82.27968752567193"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -59,8 +56,7 @@ exports[`ScreenTime should match snapshot 1`] = `
       />
       <path
         className="css-dw3c54 css-c5mv14"
-        d="M 395.36209200496467 107.39897994358567 A 100 100 0 0 1 396.1261695938319 109.93626441830011
-  "
+        d="M 395.36209200496467 107.39897994358567 A 100 100 0 0 1 396.1261695938319 109.93626441830011"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -146,8 +142,7 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
       <path
         ariaSelected={false}
         className="css-dw3c54 css-c5mv14"
-        d="M 400 137.5 A 100 100 0 1 1 230.45154089497316 65.64589896104461
-  "
+        d="M 400 137.5 A 100 100 0 1 1 230.45154089497316 65.64589896104461"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -157,8 +152,7 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
       <path
         ariaSelected={false}
         className="css-dw3c54 css-c5mv14"
-        d="M 252.95140466579025 49.25925160631412 A 100 100 0 0 1 396.1261695938319 109.93626441830011
-  "
+        d="M 252.95140466579025 49.25925160631412 A 100 100 0 0 1 396.1261695938319 109.93626441830011"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -282,8 +276,7 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
       <path
         ariaSelected={false}
         className="css-dw3c54 css-c5mv14"
-        d="M 400 137.5 A 100 100 0 1 1 230.45154089497316 65.64589896104461
-  "
+        d="M 400 137.5 A 100 100 0 1 1 230.45154089497316 65.64589896104461"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"
@@ -293,8 +286,7 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
       <path
         ariaSelected={false}
         className="css-dw3c54 css-c5mv14"
-        d="M 252.95140466579025 49.25925160631412 A 100 100 0 0 1 396.1261695938319 109.93626441830011
-  "
+        d="M 252.95140466579025 49.25925160631412 A 100 100 0 0 1 396.1261695938319 109.93626441830011"
         fill="transparent"
         onClick={[Function]}
         stroke="saltBox"


### PR DESCRIPTION
This was an issue where the graph was aggregating an "other" labeled section that only had one URL in it. This overall was not get UX and also caused an issue with a piece of logic that was to show the list modal v. the info modal. That code was not changed but the aggregation code for the attributes on the graph to use a proper label. 