### PR TITLE
Setup dark and light mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12304,6 +12304,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-color-scheme": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-color-scheme/-/use-color-scheme-1.1.1.tgz",
+      "integrity": "sha512-KqY1z+24wVSb7iSRBmB0P1LoBNMVUR11R7CiRgQaqjvP1Edj05sOdrNaLot3Sl/XUxvfWqMiojqPw9mBd4ssig=="
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "style-loader": "0.23.1",
     "terser-webpack-plugin": "1.2.3",
     "url-loader": "1.1.2",
+    "use-color-scheme": "^1.1.1",
     "webpack": "4.29.6",
     "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.0.4"

--- a/src/content.js
+++ b/src/content.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { useColorScheme } from 'use-color-scheme'
 import ContentApp from './components/content-app'
 import { BREAK_TIMER_FEATURE } from './constants'
-
 import {
   onVisibilityChange,
   onViewingStart,
   onViewingEnd,
 } from './content/timing'
+import { ColorThemeProvider } from './hooks/use-theme'
 
 onViewingStart()
 window.document.addEventListener(
@@ -25,5 +26,14 @@ if (BREAK_TIMER_FEATURE) {
 
   document.body.appendChild(el)
 
-  ReactDOM.render(<ContentApp />, el)
+  const App = () => {
+    const { scheme } = useColorScheme()
+    return (
+      <ColorThemeProvider value={scheme}>
+        <ContentApp />
+      </ColorThemeProvider>
+    )
+  }
+
+  ReactDOM.render(<App />, el)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,22 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { useColorScheme } from 'use-color-scheme'
 import App from './app'
 import { ErrorBox } from './components/error-box'
 import { ColorThemeProvider } from './hooks/use-theme'
 
 import './tracker'
 
-const NewHomePage = () => (
-  <ErrorBox>
-    <ColorThemeProvider value="dark">
-      <App />
-    </ColorThemeProvider>
-  </ErrorBox>
-)
+const NewHomePage = () => {
+  const { scheme } = useColorScheme()
+  return (
+    <ErrorBox>
+      <ColorThemeProvider value={scheme}>
+        <App />
+      </ColorThemeProvider>
+    </ErrorBox>
+  )
+}
 
 ReactDOM.render(
   <NewHomePage />,


### PR DESCRIPTION
Downloaded Chrome Canary. Now you can switch themes globally on your computer and it will switch the theme on our extension. 

This is only available on Beta Chrome until the 30th of July where it will be released for stable.

<img width="300" alt="Screen Shot 2019-06-28 at 11 28 26 AM" src="https://user-images.githubusercontent.com/578259/60363822-62508180-9999-11e9-8c98-5ea7939ea3c1.png">
<img width="300" alt="Screen Shot 2019-06-28 at 11 28 16 AM" src="https://user-images.githubusercontent.com/578259/60363823-62508180-9999-11e9-8c91-29d335fd8ba1.png">
<img width="300" alt="Screen Shot 2019-06-28 at 11 26 50 AM" src="https://user-images.githubusercontent.com/578259/60363824-62508180-9999-11e9-845b-40ead1c6b135.png">
