### PR TITLE
Not enough data placeholder

### DIFF
--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -124,65 +124,84 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
   >
     Screen Time
   </h4>
-  <svg
+  <div
     className=""
-    height="275px"
-    style={
-      Object {
-        "height": 275,
-        "width": 600,
-      }
-    }
-    width="600px"
   >
-    <g
+    <svg
       className=""
-      transform="rotate(-89, 300, 137.5)"
+      height="250"
+      width="600"
+      xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        ariaSelected={false}
-        className="css-dw3c54 css-c5mv14"
-        d="M 400 137.5 A 100 100 0 1 1 230.45154089497316 65.64589896104461"
-        fill="transparent"
-        onClick={[Function]}
-        stroke="saltBox"
+        className=""
+        d="M19 125.5h566"
+        stroke="outerSpace"
         strokeLinecap="round"
-        strokeWidth={16}
+        strokeWidth="8"
       />
-      <path
-        ariaSelected={false}
-        className="css-dw3c54 css-c5mv14"
-        d="M 252.95140466579025 49.25925160631412 A 100 100 0 0 1 396.1261695938319 109.93626441830011"
-        fill="transparent"
-        onClick={[Function]}
-        stroke="saltBox"
-        strokeLinecap="round"
-        strokeWidth={16}
+      <circle
+        className=""
+        cx="235.5"
+        cy="125.5"
+        fill="gravel"
+        fillRule="nonzero"
+        r="102.5"
+        stroke="outerSpace"
+        strokeWidth="8"
       />
-    </g>
-    <text
-      alignmentBaseline="hanging"
-      className="css-dw3c54"
-      fill="mischka"
-      onClick={[Function]}
-      textAnchor="start"
-      x={409.6534826042641}
-      y={186.24539724688213}
+      <circle
+        className=""
+        cx="521.5"
+        cy="125.5"
+        fill="gravel"
+        fillRule="nonzero"
+        r="33.5"
+        stroke="outerSpace"
+        strokeWidth="8"
+      />
+      <circle
+        className=""
+        cx="64.5"
+        cy="125.5"
+        fill="gravel"
+        fillRule="nonzero"
+        r="26.5"
+        stroke="outerSpace"
+        strokeWidth="8"
+      />
+      <circle
+        className=""
+        cx="364.5"
+        cy="39.5"
+        fill="outerSpace"
+        fillRule="nonzero"
+        r="26.5"
+      />
+      <circle
+        className=""
+        cx="456"
+        cy="126"
+        fill="outerSpace"
+        fillRule="nonzero"
+        r="15"
+      />
+      <circle
+        className=""
+        cx="419"
+        cy="126"
+        fill="outerSpace"
+        fillRule="nonzero"
+        r="15"
+      />
+    </svg>
+    <p
+      className="css-1d0qo6a css-ou8fjb css-1p3cmt4"
+      color="color"
     >
-      foo.com
-    </text>
-    <text
-      alignmentBaseline="baseline"
-      className="css-dw3c54"
-      fill="mischka"
-      onClick={[Function]}
-      textAnchor="end"
-      x={190.34651739573584}
-      y={88.75460275311792}
-    >
-      mail.bar.com
-    </text>
-  </svg>
+      Hold tight, there is not enough data to show you anything yet.
+    </p>
+  </div>
   <div
     className="css-1cqgl9p css-5uyuv6 css-16qvk6d css-z86ji4 css-1xnhsiz"
     css={
@@ -283,65 +302,84 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
   >
     Screen Time
   </h4>
-  <svg
+  <div
     className=""
-    height="275px"
-    style={
-      Object {
-        "height": 275,
-        "width": 600,
-      }
-    }
-    width="600px"
   >
-    <g
+    <svg
       className=""
-      transform="rotate(-89, 300, 137.5)"
+      height="250"
+      width="600"
+      xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        ariaSelected={false}
-        className="css-dw3c54 css-c5mv14"
-        d="M 400 137.5 A 100 100 0 1 1 230.45154089497316 65.64589896104461"
-        fill="transparent"
-        onClick={[Function]}
-        stroke="saltBox"
+        className=""
+        d="M19 125.5h566"
+        stroke="outerSpace"
         strokeLinecap="round"
-        strokeWidth={16}
+        strokeWidth="8"
       />
-      <path
-        ariaSelected={false}
-        className="css-dw3c54 css-c5mv14"
-        d="M 252.95140466579025 49.25925160631412 A 100 100 0 0 1 396.1261695938319 109.93626441830011"
-        fill="transparent"
-        onClick={[Function]}
-        stroke="saltBox"
-        strokeLinecap="round"
-        strokeWidth={16}
+      <circle
+        className=""
+        cx="235.5"
+        cy="125.5"
+        fill="gravel"
+        fillRule="nonzero"
+        r="102.5"
+        stroke="outerSpace"
+        strokeWidth="8"
       />
-    </g>
-    <text
-      alignmentBaseline="hanging"
-      className="css-dw3c54"
-      fill="mischka"
-      onClick={[Function]}
-      textAnchor="start"
-      x={409.6534826042641}
-      y={186.24539724688213}
+      <circle
+        className=""
+        cx="521.5"
+        cy="125.5"
+        fill="gravel"
+        fillRule="nonzero"
+        r="33.5"
+        stroke="outerSpace"
+        strokeWidth="8"
+      />
+      <circle
+        className=""
+        cx="64.5"
+        cy="125.5"
+        fill="gravel"
+        fillRule="nonzero"
+        r="26.5"
+        stroke="outerSpace"
+        strokeWidth="8"
+      />
+      <circle
+        className=""
+        cx="364.5"
+        cy="39.5"
+        fill="outerSpace"
+        fillRule="nonzero"
+        r="26.5"
+      />
+      <circle
+        className=""
+        cx="456"
+        cy="126"
+        fill="outerSpace"
+        fillRule="nonzero"
+        r="15"
+      />
+      <circle
+        className=""
+        cx="419"
+        cy="126"
+        fill="outerSpace"
+        fillRule="nonzero"
+        r="15"
+      />
+    </svg>
+    <p
+      className="css-1d0qo6a css-ou8fjb css-1p3cmt4"
+      color="color"
     >
-      foo.com
-    </text>
-    <text
-      alignmentBaseline="baseline"
-      className="css-dw3c54"
-      fill="mischka"
-      onClick={[Function]}
-      textAnchor="end"
-      x={190.34651739573584}
-      y={88.75460275311792}
-    >
-      mail.bar.com
-    </text>
-  </svg>
+      Hold tight, there is not enough data to show you anything yet.
+    </p>
+  </div>
   <div
     className="css-1cqgl9p css-5uyuv6 css-16qvk6d css-z86ji4 css-1xnhsiz"
     css={

--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -199,7 +199,7 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
       className="css-1d0qo6a css-ou8fjb css-1p3cmt4"
       color="color"
     >
-      Hold tight, there is not enough data to show you anything yet.
+      Explore more, there is not enough data to show you anything yet.
     </p>
   </div>
   <div
@@ -377,7 +377,7 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
       className="css-1d0qo6a css-ou8fjb css-1p3cmt4"
       color="color"
     >
-      Hold tight, there is not enough data to show you anything yet.
+      Explore more, there is not enough data to show you anything yet.
     </p>
   </div>
   <div

--- a/src/components/screen-time/index.js
+++ b/src/components/screen-time/index.js
@@ -5,6 +5,7 @@ import { siteTimeToChartData } from '../../lib/aggregation'
 import { HeaderS } from '../fonts'
 import { Graph } from '../graph'
 import { Modal } from './modal'
+import { NotEnoughData, hasEnoughData } from './not-enough-data'
 import { reduceSegmentToUrls } from './reducer'
 
 export const ScreenTime = ({
@@ -16,6 +17,7 @@ export const ScreenTime = ({
   const graphData = siteTimeToChartData(data)
   const theme = useTheme()
   const { foreground, highlight } = theme
+  const showGraph = hasEnoughData(graphData, data)
   return (
     <Box
       flex="1"
@@ -28,22 +30,26 @@ export const ScreenTime = ({
       layer="1"
     >
       <HeaderS color={foreground}>Screen Time</HeaderS>
-      <Graph
-        data={graphData}
-        width={600}
-        height={275}
-        strokeWidth={16}
-        textFill={foreground}
-        stroke={highlight}
-        spacingAngle={16}
-        strokeLinecap="round"
-        radius={100}
-        selected={selectedSegment}
-        selectedStroke={foreground}
-        onSegmentClick={seg =>
-          setSelectedSegment(reduceSegmentToUrls(seg))
-        }
-      />
+      {showGraph ? (
+        <Graph
+          data={graphData}
+          width={600}
+          height={275}
+          strokeWidth={16}
+          textFill={foreground}
+          stroke={highlight}
+          spacingAngle={16}
+          strokeLinecap="round"
+          radius={100}
+          selected={selectedSegment}
+          selectedStroke={foreground}
+          onSegmentClick={seg =>
+            setSelectedSegment(reduceSegmentToUrls(seg))
+          }
+        />
+      ) : (
+        <NotEnoughData />
+      )}
       {selectedSegment ? (
         <Modal
           theme={theme}

--- a/src/components/screen-time/not-enough-data.js
+++ b/src/components/screen-time/not-enough-data.js
@@ -1,0 +1,88 @@
+import { Box } from '@jcblw/box'
+import React from 'react'
+import { MINUTE } from '../../constants'
+import { useTheme } from '../../hooks/use-theme'
+import { getTotalTime } from '../../lib/aggregation'
+import { BodyS } from '../fonts'
+
+export const hasEnoughData = (segments, data) =>
+  segments.length >= 2 && getTotalTime(data) >= MINUTE
+
+export const NotEnoughData = props => {
+  const theme = useTheme()
+  return (
+    <Box>
+      <Box
+        Component="svg"
+        width="600"
+        height="250"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <Box
+          Component="path"
+          d="M19 125.5h566"
+          stroke={theme.background}
+          strokeWidth="8"
+          strokeLinecap="round"
+        />
+        <Box
+          Component="circle"
+          stroke={theme.background}
+          strokeWidth="8"
+          fill={theme.backgroundSecondary}
+          fillRule="nonzero"
+          cx="235.5"
+          cy="125.5"
+          r="102.5"
+        />
+        <Box
+          Component="circle"
+          stroke={theme.background}
+          strokeWidth="8"
+          fill={theme.backgroundSecondary}
+          fillRule="nonzero"
+          cx="521.5"
+          cy="125.5"
+          r="33.5"
+        />
+        <Box
+          Component="circle"
+          stroke={theme.background}
+          strokeWidth="8"
+          fill={theme.backgroundSecondary}
+          fillRule="nonzero"
+          cx="64.5"
+          cy="125.5"
+          r="26.5"
+        />
+        <Box
+          Component="circle"
+          fill={theme.background}
+          fillRule="nonzero"
+          cx="364.5"
+          cy="39.5"
+          r="26.5"
+        />
+        <Box
+          Component="circle"
+          fill={theme.background}
+          fillRule="nonzero"
+          cx="456"
+          cy="126"
+          r="15"
+        />
+        <Box
+          Component="circle"
+          fill={theme.background}
+          fillRule="nonzero"
+          cx="419"
+          cy="126"
+          r="15"
+        />
+      </Box>
+      <BodyS>
+        Hold tight, there is not enough data to show you anything yet.
+      </BodyS>
+    </Box>
+  )
+}

--- a/src/components/screen-time/not-enough-data.js
+++ b/src/components/screen-time/not-enough-data.js
@@ -81,7 +81,8 @@ export const NotEnoughData = props => {
         />
       </Box>
       <BodyS>
-        Hold tight, there is not enough data to show you anything yet.
+        Explore more, there is not enough data to show you anything
+        yet.
       </BodyS>
     </Box>
   )

--- a/src/components/screen-time/not-enough-data.test.js
+++ b/src/components/screen-time/not-enough-data.test.js
@@ -1,0 +1,16 @@
+import { hasEnoughData } from './not-enough-data'
+
+test('hasEnoughData should return true when there is enough data', () => {
+  const segments = [{}, {}] // two segments
+  const data = { foo: { time: 1000 * 61 } } // over a minute
+  expect(hasEnoughData(segments, data)).toBe(true)
+})
+
+test('hasEnoughData should return false when there is not enough data', () => {
+  // not enough segments
+  expect(hasEnoughData([{}], { foo: { time: 1000 * 61 } })).toBe(
+    false
+  )
+  // not enough time
+  expect(hasEnoughData([{}, {}], { foo: { time: 1 } })).toBe(false)
+})


### PR DESCRIPTION
This is a placeholder outlined in https://www.notion.so/jjcblw/Screen-Time-not-enough-data-place-holder-a0d2ceadd4cb45ea95776abfd191d20b

Changed the logic only a little to only require two sites.

<img width="300" alt="Screen Shot 2019-06-30 at 12 02 53 PM" src="https://user-images.githubusercontent.com/578259/60401207-d1ada900-9b32-11e9-81fc-0c55635227e7.png">
<img width="300" alt="Screen Shot 2019-06-30 at 12 02 13 PM" src="https://user-images.githubusercontent.com/578259/60401208-d1ada900-9b32-11e9-9e92-d7bce61b252c.png">

The copy was changed from stuff in the screenshot to "Explore more, there is not enough data to show you anything yet." to match the planet like icons
