### PR TITLE
Make Screen Time Permission Optional

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,16 +10,14 @@
   },
   "permissions": [
     "tabs",
-    "activeTab",
     "webNavigation",
     "notifications",
     "alarms",
     "background",
     "topSites",
-    "chrome://favicon/",
-    "https://*/*",
-    "http://*/*"
+    "chrome://favicon/"
   ],
+  "optional_permissions": ["activeTab", "https://*/*", "http://*/*"],
   "icons": {
     "16": "favicon.png",
     "32": "favicon.png",

--- a/src/background/inject.js
+++ b/src/background/inject.js
@@ -1,9 +1,12 @@
-import { SCREEN_TIME_FEATURE } from '../constants'
-import { tabs } from '../lib/extension'
+import {
+  SCREEN_TIME_FEATURE,
+  SCREEN_TIME_PERMISSIONS,
+} from '../constants'
+import { tabs, permissions } from '../lib/extension'
 
 const BLACK_LIST = ['about:blank', 'chrome']
 
-export const injectScript = tab => {
+export const injectScript = async tab => {
   const isBlackListed = BLACK_LIST.some(url =>
     tab.url.startsWith(url)
   )
@@ -11,5 +14,9 @@ export const injectScript = tab => {
   if (isBlackListed || isSubFrame || !SCREEN_TIME_FEATURE) {
     return
   }
+  const hasPermission = await permissions.contains(
+    SCREEN_TIME_PERMISSIONS
+  )
+  if (!hasPermission) return
   tabs.executeScript(tab.tabId, { file: 'content.js' })
 }

--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -146,6 +146,50 @@ exports[`ScreenTime should match snapshot 1`] = `
       other
     </text>
   </svg>
+  <button
+    backgroundColor="outerSpace"
+    className="css-h0biv2 css-5uyuv6 css-1k8tu3j css-1okiobr css-yxn9bq css-1pev02g css-7ep5t css-b9abf0 css-1xg3sco css-1dnwvu3 css-1kvvogt"
+    color="mischka"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    outlineColor="saltBox"
+    position="relative"
+  >
+    Enable
+    <div
+      className=""
+      position="relative"
+    >
+      <div
+        className="css-1yv2jt6 css-1ivoip3 css-1cqgl9p css-1vwvlri"
+        position="absolute"
+      >
+        <span
+          backgroundColor="mischka"
+          className="css-1xg3sco css-1okiobr css-1pev02g css-1jw2j5g css-fxshz5 css-xm5bud"
+          color="outerSpace"
+          position="relative"
+        >
+          <div
+            backgroundColor="mischka"
+            className="css-1tdptiz css-1ijci28"
+            position="absolute"
+          />
+          <div
+            className="css-4ptacf"
+            position="relative"
+          >
+            <span
+              className=""
+            >
+              Screen time will need to ask for some elevated permissions to track viewing times.
+            </span>
+          </div>
+        </span>
+      </div>
+    </div>
+  </button>
 </div>
 `;
 
@@ -276,6 +320,50 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
       Explore more, there is not enough data to show you anything yet.
     </p>
   </div>
+  <button
+    backgroundColor="outerSpace"
+    className="css-h0biv2 css-5uyuv6 css-1k8tu3j css-1okiobr css-yxn9bq css-1pev02g css-7ep5t css-b9abf0 css-1xg3sco css-1dnwvu3 css-1kvvogt"
+    color="mischka"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    outlineColor="saltBox"
+    position="relative"
+  >
+    Enable
+    <div
+      className=""
+      position="relative"
+    >
+      <div
+        className="css-1yv2jt6 css-1ivoip3 css-1cqgl9p css-1vwvlri"
+        position="absolute"
+      >
+        <span
+          backgroundColor="mischka"
+          className="css-1xg3sco css-1okiobr css-1pev02g css-1jw2j5g css-fxshz5 css-xm5bud"
+          color="outerSpace"
+          position="relative"
+        >
+          <div
+            backgroundColor="mischka"
+            className="css-1tdptiz css-1ijci28"
+            position="absolute"
+          />
+          <div
+            className="css-4ptacf"
+            position="relative"
+          >
+            <span
+              className=""
+            >
+              Screen time will need to ask for some elevated permissions to track viewing times.
+            </span>
+          </div>
+        </span>
+      </div>
+    </div>
+  </button>
   <div
     className="css-1cqgl9p css-5uyuv6 css-16qvk6d css-z86ji4 css-1xnhsiz"
     css={
@@ -491,6 +579,50 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
       Explore more, there is not enough data to show you anything yet.
     </p>
   </div>
+  <button
+    backgroundColor="outerSpace"
+    className="css-h0biv2 css-5uyuv6 css-1k8tu3j css-1okiobr css-yxn9bq css-1pev02g css-7ep5t css-b9abf0 css-1xg3sco css-1dnwvu3 css-1kvvogt"
+    color="mischka"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    outlineColor="saltBox"
+    position="relative"
+  >
+    Enable
+    <div
+      className=""
+      position="relative"
+    >
+      <div
+        className="css-1yv2jt6 css-1ivoip3 css-1cqgl9p css-1vwvlri"
+        position="absolute"
+      >
+        <span
+          backgroundColor="mischka"
+          className="css-1xg3sco css-1okiobr css-1pev02g css-1jw2j5g css-fxshz5 css-xm5bud"
+          color="outerSpace"
+          position="relative"
+        >
+          <div
+            backgroundColor="mischka"
+            className="css-1tdptiz css-1ijci28"
+            position="absolute"
+          />
+          <div
+            className="css-4ptacf"
+            position="relative"
+          >
+            <span
+              className=""
+            >
+              Screen time will need to ask for some elevated permissions to track viewing times.
+            </span>
+          </div>
+        </span>
+      </div>
+    </div>
+  </button>
   <div
     className="css-1cqgl9p css-5uyuv6 css-16qvk6d css-z86ji4 css-1xnhsiz"
     css={

--- a/src/components/screen-time/index.js
+++ b/src/components/screen-time/index.js
@@ -1,7 +1,10 @@
 import { Box } from '@jcblw/box'
 import React, { useState } from 'react'
+import { SCREEN_TIME_PERMISSIONS } from '../../constants'
+import { usePermissions } from '../../hooks/use-permissions'
 import { useTheme } from '../../hooks/use-theme'
 import { siteTimeToChartData } from '../../lib/aggregation'
+import { Button } from '../button'
 import { HeaderS, Sup } from '../fonts'
 import { Graph } from '../graph'
 import { ToolTip } from '../tool-tip'
@@ -16,6 +19,11 @@ export const ScreenTime = ({
   setSelectedSegment,
 }) => {
   const [toolTipOpen, setToolTipOpen] = useState(false)
+  const {
+    hasPermission,
+    requestPermissions,
+    removePermissions,
+  } = usePermissions(SCREEN_TIME_PERMISSIONS)
   const graphData = siteTimeToChartData(data)
   const theme = useTheme()
   const { foreground, highlight } = theme
@@ -62,6 +70,23 @@ export const ScreenTime = ({
         />
       ) : (
         <NotEnoughData />
+      )}
+      {!hasPermission ? (
+        <Button
+          onClick={requestPermissions}
+          alt="We need more permissions"
+          design={theme.buttonStyle}
+        >
+          Enable Screen Time
+        </Button>
+      ) : (
+        <Button
+          onClick={removePermissions}
+          alt="Revoke access to permissions"
+          design={theme.buttonStyle}
+        >
+          Disable Screen Time
+        </Button>
       )}
       {selectedSegment ? (
         <Modal

--- a/src/components/screen-time/index.js
+++ b/src/components/screen-time/index.js
@@ -74,18 +74,28 @@ export const ScreenTime = ({
       {!hasPermission ? (
         <Button
           onClick={requestPermissions}
-          alt="We need more permissions"
+          alt={
+            <Box Component="span">
+              Screen time will need to ask for some elevated
+              permissions to track viewing times.
+            </Box>
+          }
           design={theme.buttonStyle}
         >
-          Enable Screen Time
+          Enable
         </Button>
       ) : (
         <Button
           onClick={removePermissions}
-          alt="Revoke access to permissions"
+          alt={
+            <Box Component="span">
+              This will remove the permissions that are needed for
+              Screen Time to function.
+            </Box>
+          }
           design={theme.buttonStyle}
         >
-          Disable Screen Time
+          Disable
         </Button>
       )}
       {selectedSegment ? (

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,3 +33,9 @@ export const SET_STORAGE = 'SET_STORAGE'
 // Feature Flags
 export const SCREEN_TIME_FEATURE = true
 export const BREAK_TIMER_FEATURE = false
+
+// OPTIONAL permissions requested
+export const SCREEN_TIME_PERMISSIONS = {
+  permissions: ['activeTab'],
+  origins: ['https://*/*', 'http://*/*'],
+}

--- a/src/hooks/use-permissions.js
+++ b/src/hooks/use-permissions.js
@@ -1,0 +1,38 @@
+import { useState, useEffect, useCallback } from 'react'
+import { permissions } from '../lib/extension'
+
+export const usePermissions = perms => {
+  const [hasPermission, setHasPermission] = useState(false)
+
+  const requestPermissions = useCallback(async () => {
+    if (hasPermission) return // no use asking for permissions we already have
+    const granted = await permissions.request(perms)
+    if (granted) {
+      setHasPermission(granted)
+    }
+  }, [hasPermission, perms])
+
+  const removePermissions = useCallback(async () => {
+    if (!hasPermission) return // no use asking for permissions we already have
+    const removed = await permissions.remove(perms)
+    if (removed) {
+      setHasPermission(false)
+    }
+  }, [hasPermission, perms])
+
+  useEffect(() => {
+    const check = async () => {
+      const granted = await permissions.contains(perms)
+      if (hasPermission !== granted) {
+        setHasPermission(granted)
+      }
+    }
+    check()
+  }, [hasPermission, perms, setHasPermission])
+
+  return {
+    hasPermission,
+    requestPermissions,
+    removePermissions,
+  }
+}

--- a/src/lib/extension.js
+++ b/src/lib/extension.js
@@ -1,4 +1,5 @@
 import { GET_STORAGE, SET_STORAGE } from '../constants'
+import { promisifyObject } from './promisify'
 /*
   Extension Lib
   -----
@@ -31,6 +32,8 @@ export const setStorage = async (key, value) => {
 export const onMessage = (...args) => {
   chrome.runtime.onMessage.addListener(...args)
 }
+
+export const permissions = promisifyObject(chrome.permissions)
 
 export const {
   alarms,

--- a/src/lib/promisify.js
+++ b/src/lib/promisify.js
@@ -1,0 +1,24 @@
+import { set } from './util'
+
+// chrome passes results as first object
+export const promisify = fn => (...args) =>
+  new Promise(resolve => {
+    fn(...args, resolve)
+  })
+
+export const promisifyObject = (obj = {}) =>
+  Object.keys(obj).reduce((accum, method) => {
+    if (typeof obj[method] === 'function') {
+      set(accum, method, promisify(obj[method].bind(obj)))
+    }
+    return accum
+  }, {})
+
+// node pattern is usually error first then results
+export const promisifyNode = fn => (...args) =>
+  new Promise((resolve, reject) => {
+    fn(...args, (err, results) => {
+      if (err) return reject(err)
+      return resolve(results)
+    }) // chrome passes results as first object
+  })


### PR DESCRIPTION
Screen Time takes some crazy permissions. It can scare people before they install the extension so let's make it optional by default and request the permission when the user enables it. @itsjustmath want your opinion on this. Seems like a good change for the privacy-conscious.

<img width="714" alt="Screen Shot 2019-07-02 at 11 35 44 AM" src="https://user-images.githubusercontent.com/578259/60537616-c63ab900-9cbd-11e9-8725-e65ea2ba40f9.png">
<img width="620" alt="Screen Shot 2019-07-02 at 11 35 39 AM" src="https://user-images.githubusercontent.com/578259/60537617-c63ab900-9cbd-11e9-9191-ca82f826bcb2.png">


This was brought up by @motdotla in a text message saying that the extension was asking for some crazy permissions.

![Screen_Sh](https://user-images.githubusercontent.com/578259/60537598-bcb15100-9cbd-11e9-87f7-8170cc12dae9.jpg)
