### PR TITLE
Swap DB to indexDB

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,5 @@
+import 'fake-indexeddb/auto'
+
 jest.mock('./src/lib/extension')
 
 // this is just a little hack to silence a warning that we'll get until react

--- a/package-lock.json
+++ b/package-lock.json
@@ -2262,6 +2262,11 @@
         }
       }
     },
+    "base64-arraybuffer-es6": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.5.0.tgz",
+      "integrity": "sha512-UCIPaDJrNNj5jG2ZL+nzJ7czvZV/ZYX6LaIRgfVU1k1edJOQg7dkbiSKzwHkNp6aHEHER/PhlFBrMYnlvJJQEw=="
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -5575,6 +5580,23 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fake-indexeddb": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-2.1.1.tgz",
+      "integrity": "sha512-di5PzbH6/gleD4qcpxT1IDtNNMTKuEs+C2KeJDP1e4mwP2L0UY+vPcTkCdIGq8IcaUUph6IkCrUZJvtpFUdhfg==",
+      "requires": {
+        "core-js": "^2.4.1",
+        "realistic-structured-clone": "^2.0.1",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -10374,6 +10396,24 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "realistic-structured-clone": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-2.0.2.tgz",
+      "integrity": "sha512-5IEvyfuMJ4tjQOuKKTFNvd+H9GSbE87IcendSBannE28PTrbolgaVg5DdEApRKhtze794iXqVUFKV60GLCNKEg==",
+      "requires": {
+        "core-js": "^2.5.3",
+        "domexception": "^1.0.1",
+        "typeson": "^5.8.2",
+        "typeson-registry": "^1.0.0-alpha.20"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        }
+      }
+    },
     "realpath-native": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -12038,6 +12078,33 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typeson": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-5.13.0.tgz",
+      "integrity": "sha512-xcSaSt+hY/VcRYcqZuVkJwMjDXXJb4CZd51qDocpYw8waA314ygyOPlKhsGsw4qKuJ0tfLLUrxccrm+xvyS0AQ=="
+    },
+    "typeson-registry": {
+      "version": "1.0.0-alpha.28",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.28.tgz",
+      "integrity": "sha512-WQD4dPXak+20mUiFFeaI0xh+dqiMQs2fmPFzX6akg1+WN74ocVFjYFwRbWNdtLuCUomxXrxAMP9dxjCakZQHvQ==",
+      "requires": {
+        "base64-arraybuffer-es6": "0.5.0",
+        "typeson": "5.13.0",
+        "whatwg-url": "7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
     },
     "ua-parser-js": {
       "version": "0.7.19",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-react-hooks": "^1.5.0",
+    "fake-indexeddb": "^2.1.1",
     "file-loader": "3.0.1",
     "filesize": "^4.1.2",
     "fs-extra": "7.0.1",
@@ -89,10 +90,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statments": 60,
-        "branches": 35,
-        "functions": 50,
-        "lines": 60
+        "statments": 65,
+        "branches": 40,
+        "functions": 55,
+        "lines": 65
       }
     },
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -90,15 +90,16 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statments": 65,
-        "branches": 40,
-        "functions": 55,
-        "lines": 65
+        "statments": 70,
+        "branches": 45,
+        "functions": 60,
+        "lines": 70
       }
     },
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",
-      "!src/**/*.d.ts"
+      "!src/**/*.d.ts",
+      "!src/background/storage/migrations/*.js"
     ],
     "setupFiles": [
       "react-app-polyfill/jsdom"

--- a/src/background.test.js
+++ b/src/background.test.js
@@ -1,0 +1,23 @@
+/* eslint-disable-next-line import-order-alphabetical/order */
+import {
+  onMessage,
+  alarms,
+  webNavigation,
+  notifications,
+} from './lib/extension'
+
+jest.mock('./background/alarm')
+jest.mock('./background/tracking')
+const { addHeartBeat } = require('./background/alarm')
+const { injectTracking } = require('./background/tracking')
+
+test('all the automatic setup of background', () => {
+  /* eslint-disable-next-line global-require */
+  require('./background')
+  expect(onMessage).toBeCalled()
+  expect(alarms.onAlarm.addListener).toBeCalled()
+  expect(webNavigation.onCommitted.addListener).toBeCalled()
+  expect(notifications.onClicked.addListener).toBeCalled()
+  expect(addHeartBeat).toBeCalled()
+  expect(injectTracking).toBeCalled()
+})

--- a/src/background/activity/index.js
+++ b/src/background/activity/index.js
@@ -10,6 +10,7 @@ import {
 import { toSiteInfo, getTotalTime } from '../../lib/aggregation'
 import statsModel from '../../model'
 import { storage } from '../storage'
+import { addLatestActivity } from '../storage/index-db'
 
 export const activityStatKeys = [
   PAGE_VIEWS_KEY,
@@ -55,5 +56,6 @@ export const setLastActive = async date => {
     // reset activity before setting last active
     await resetUsage()
   }
+  await addLatestActivity(now)
   return storage.set(LAST_ACTIVE_KEY, +now)
 }

--- a/src/background/inject.js
+++ b/src/background/inject.js
@@ -1,7 +1,4 @@
-import {
-  SCREEN_TIME_FEATURE,
-  SCREEN_TIME_PERMISSIONS,
-} from '../constants'
+import { SCREEN_TIME_PERMISSIONS } from '../constants'
 import { tabs, permissions } from '../lib/extension'
 
 const BLACK_LIST = ['about:blank', 'chrome']
@@ -11,7 +8,7 @@ export const injectScript = async tab => {
     tab.url.startsWith(url)
   )
   const isSubFrame = tab.transitionType === '"auto_subframe"'
-  if (isBlackListed || isSubFrame || !SCREEN_TIME_FEATURE) {
+  if (isBlackListed || isSubFrame) {
     return
   }
   const hasPermission = await permissions.contains(

--- a/src/background/inject.test.js
+++ b/src/background/inject.test.js
@@ -1,0 +1,31 @@
+import { SCREEN_TIME_PERMISSIONS } from '../constants'
+import { tabs, permissions } from '../lib/extension'
+import { injectScript } from './inject'
+
+test('injectScript should not inject script a black list url', async () => {
+  await injectScript({ url: 'chrome://newtab' })
+  expect(tabs.executeScript).not.toBeCalled()
+})
+
+test('injectScript should not inject script a sub frame', async () => {
+  await injectScript({
+    url: 'https://foo',
+    transitionType: '"auto_subframe"',
+  })
+  expect(tabs.executeScript).not.toBeCalled()
+})
+
+test('injectScript should not inject script if no permissions', async () => {
+  permissions.contains.mockResolvedValueOnce(false)
+  await injectScript({ url: 'https://foo' })
+  expect(permissions.contains).toBeCalledWith(SCREEN_TIME_PERMISSIONS)
+  expect(tabs.executeScript).not.toBeCalled()
+})
+
+test('injectScript should inject script if there is permissions', async () => {
+  const file = { file: 'content.js' }
+  permissions.contains.mockResolvedValueOnce(true)
+  await injectScript({ url: 'https://foo', tabId: 'foo' })
+  expect(permissions.contains).toBeCalledWith(SCREEN_TIME_PERMISSIONS)
+  expect(tabs.executeScript).toBeCalledWith('foo', file)
+})

--- a/src/background/message-reducer.js
+++ b/src/background/message-reducer.js
@@ -65,4 +65,5 @@ export const reducer = (request, sender, sendResponse) => {
   }
   // set last active time to indicate user is currently active
   setLastActive()
+  return true // must return true if there is a reponse
 }

--- a/src/background/message-reducer.js
+++ b/src/background/message-reducer.js
@@ -7,6 +7,8 @@ import {
   DEEP_LINK_NEWTAB,
   ALARM_KEY,
   TRACK,
+  ADD_BROADCAST_TAB,
+  REMOVE_BROADCAST_TAB,
 } from '../constants'
 import { tabs } from '../lib/extension'
 import {
@@ -18,12 +20,19 @@ import {
 import { handleAlarmToggle, addBreakAlarm } from './alarm'
 import { updateScreenTime } from './screen-time'
 import { onGetStorage, onSetStorage } from './storage'
+import { broadcaster } from './storage/broadcast'
 import { addData } from './tracking'
 
 export const reducer = (request, sender, sendResponse) => {
   const { event } = request
   let hasResponse = false
   switch (event) {
+    case ADD_BROADCAST_TAB:
+      broadcaster.add(sender.tab)
+      break
+    case REMOVE_BROADCAST_TAB:
+      broadcaster.remove(sender.tab)
+      break
     case NEW_TAB_CONNECTION:
       addData({ event: 'pageView' }) // custom event for pageviews
       addBreakAlarm()

--- a/src/background/message-reducer.test.js
+++ b/src/background/message-reducer.test.js
@@ -1,0 +1,7 @@
+import { reducer } from './message-reducer'
+
+test('reducer should return true', () => {
+  const mockResponse = jest.fn()
+  expect(reducer({}, {}, mockResponse)).toBe(true)
+  expect(mockResponse).toBeCalledWith({ success: true })
+})

--- a/src/background/screen-time.test.js
+++ b/src/background/screen-time.test.js
@@ -1,0 +1,21 @@
+import { SITE_TIME_KEY } from '../constants'
+import { updateScreenTime } from './screen-time'
+import { storage } from './storage'
+
+test('updateScreenTime should add url key', async () => {
+  const url = 'https://foo.com/bar'
+  const shortURL = 'https://foo.com'
+  await storage.set(SITE_TIME_KEY, undefined)
+  await updateScreenTime(url, [{ duration: 1 }])
+  const screenTimes = await storage.get(SITE_TIME_KEY)
+  expect(screenTimes[shortURL]).toBe(1)
+})
+
+test('updateScreenTime should update the time in storage', async () => {
+  const url = 'https://foo.com/bar'
+  const shortURL = 'https://foo.com'
+  await storage.set(SITE_TIME_KEY, { [shortURL]: 1 })
+  await updateScreenTime(url, [{ duration: 1 }, { duration: 2 }])
+  const screenTimes = await storage.get(SITE_TIME_KEY)
+  expect(screenTimes[shortURL]).toBe(4)
+})

--- a/src/background/storage/broadcast.js
+++ b/src/background/storage/broadcast.js
@@ -1,0 +1,61 @@
+// NOTE: array of tab ids
+import { tabs } from '../../lib/extension'
+import { curry } from '../../lib/functional'
+import { addData } from '../tracking'
+
+export const containsTab = curry((connections, tabId) =>
+  connections.includes(tabId)
+)
+
+export const addTab = curry((connections, tab) => {
+  const { id } = tab
+  const hasTab = containsTab(connections, id)
+  if (hasTab) return
+  connections.push(id)
+})
+
+export const removeTab = curry((connections, tab) => {
+  const index = connections.indexOf(tab.id)
+  if (index === -1) return
+  connections.splice(index, 1)
+})
+
+export const broadcastToTabs = curry((connections, message) =>
+  connections.forEach(tabId => {
+    try {
+      tabs.sendMessage(tabId, message)
+    } catch (e) {
+      addData({
+        event: 'exception',
+        errorMessage: e.message,
+        errorStack: e.stack,
+      })
+    }
+  })
+)
+
+export const onTabRemoved = connections => tabId => {
+  const hasTab = containsTab(connections, tabId)
+  if (hasTab) {
+    removeTab(connections, { id: tabId })
+  }
+}
+
+export const removeListener = listener => () => {
+  tabs.onRemoved.removeListener(listener)
+}
+
+export const createBroadcaster = connections => {
+  const listener = onTabRemoved(connections)
+  tabs.onRemoved.addListener(listener)
+  return {
+    add: addTab(connections),
+    remove: removeTab(connections),
+    broadcast: broadcastToTabs(connections),
+    contains: containsTab(connections),
+    removeListener: removeListener(listener),
+    connections,
+  }
+}
+
+export const broadcaster = createBroadcaster([])

--- a/src/background/storage/broadcast.test.js
+++ b/src/background/storage/broadcast.test.js
@@ -10,6 +10,7 @@ import {
 } from './broadcast'
 
 jest.mock('../tracking')
+/* eslint-disable-next-line import-order-alphabetical/order */
 const { addData } = require('../tracking')
 
 test('createBroadcaster should create a broadcaster interface', () => {

--- a/src/background/storage/broadcast.test.js
+++ b/src/background/storage/broadcast.test.js
@@ -1,0 +1,108 @@
+import { tabs } from '../../lib/extension'
+import {
+  createBroadcaster,
+  onTabRemoved,
+  broadcastToTabs,
+  removeTab,
+  addTab,
+  containsTab,
+  removeListener,
+} from './broadcast'
+
+jest.mock('../tracking')
+const { addData } = require('../tracking')
+
+test('createBroadcaster should create a broadcaster interface', () => {
+  const connections = ['foo']
+  const broadcaster = createBroadcaster(connections)
+  expect(tabs.onRemoved.addListener).toBeCalled()
+  expect(typeof broadcaster.add).toBe('function')
+  expect(typeof broadcaster.remove).toBe('function')
+  expect(typeof broadcaster.broadcast).toBe('function')
+  expect(typeof broadcaster.remove).toBe('function')
+  expect(typeof broadcaster.contains).toBe('function')
+  expect(typeof broadcaster.removeListener).toBe('function')
+  expect(broadcaster.connections).toEqual(connections)
+})
+
+test('onTabRemoved should return a function', () => {
+  expect(typeof onTabRemoved([])).toBe('function')
+})
+
+test('onTabRemoved should remove tab from connections', () => {
+  const connections = ['foo']
+  onTabRemoved(connections)('foo')
+  expect(connections.includes('foo')).toBe(false)
+})
+
+test('onTabRemoved should remove tab from connections', () => {
+  const connections = ['foo']
+  onTabRemoved(connections)('foo')
+  expect(connections.includes('foo')).toBe(false)
+})
+
+test('broadcastToTabs should send a message to connections', () => {
+  const connections = ['foo', 'bar']
+  const message = { event: 'baz' }
+  broadcastToTabs(connections, message)
+  expect(tabs.sendMessage).toBeCalledTimes(2)
+  expect(tabs.sendMessage).toHaveBeenNthCalledWith(1, 'foo', message)
+  expect(tabs.sendMessage).toHaveBeenNthCalledWith(2, 'bar', message)
+})
+
+test('broadcastToTabs if error occurs it should be tracked', () => {
+  tabs.sendMessage.mockImplementation(() => {
+    throw new Error('foo')
+  })
+  broadcastToTabs(['foo'], {})
+  expect(addData).toBeCalledWith(
+    expect.objectContaining({
+      event: 'exception',
+      errorMessage: 'foo',
+    })
+  )
+})
+
+test('removeTab should remove tabId from connections', () => {
+  const connections = ['foo', 'bar']
+  removeTab(connections, { id: 'bar' })
+  expect(connections).toEqual(['foo'])
+})
+
+test('removeTab should not remove anything if tab is not found', () => {
+  const connections = ['foo']
+  removeTab(connections, { id: 'bar' })
+  expect(connections).toEqual(['foo'])
+})
+
+test('addTab should add tabId from connections', () => {
+  const connections = ['foo']
+  addTab(connections, { id: 'bar' })
+  expect(connections).toEqual(['foo', 'bar'])
+})
+
+test('addTab should not add a tab if the tab is already present', () => {
+  const connections = ['foo']
+  addTab(connections, { id: 'foo' })
+  expect(connections).toEqual(['foo'])
+})
+
+test('containsTab should return true if tab is in connection', () => {
+  const connections = ['foo']
+  expect(containsTab(connections, 'foo')).toBe(true)
+})
+
+test('containsTab should return false if tab is in connection', () => {
+  const connections = ['foo']
+  expect(containsTab(connections, 'bar')).toBe(false)
+})
+
+test('removeListener should return a function', () => {
+  expect(typeof removeListener()).toBe('function')
+})
+
+test('removeListener should attempt to remove listener', () => {
+  const listener = () => {}
+  removeListener(listener)()
+  expect(tabs.onRemoved.removeListener).toBeCalledWith(listener)
+})

--- a/src/background/storage/index-db.js
+++ b/src/background/storage/index-db.js
@@ -9,11 +9,13 @@ import {
 } from '../../constants'
 import { set } from '../../lib/util'
 import { broadcaster } from './broadcast'
+import { migrate } from './migrations'
 import { types } from './types'
 
 export const open = async () =>
   openDB(DATABASE_NAME, DATABASE_VERSION, {
-    upgrade(db) {
+    upgrade(db, lastVersion, currentVersion, transaction) {
+      // initial setup
       db.createObjectStore(DATABASE_STORE)
       const activityStore = db.createObjectStore(
         LAST_ACTIVITY_TABLE,
@@ -23,6 +25,9 @@ export const open = async () =>
         }
       )
       activityStore.createIndex('date', 'date')
+
+      // migrations
+      return migrate(lastVersion, currentVersion, transaction)
     },
   })
 

--- a/src/background/storage/index-db.js
+++ b/src/background/storage/index-db.js
@@ -14,7 +14,7 @@ import { types } from './types'
 
 export const open = async () =>
   openDB(DATABASE_NAME, DATABASE_VERSION, {
-    upgrade(db, lastVersion, currentVersion, transaction) {
+    upgrade: async (db, lastVersion, currentVersion, transaction) => {
       // initial setup
       db.createObjectStore(DATABASE_STORE)
       const activityStore = db.createObjectStore(
@@ -26,8 +26,10 @@ export const open = async () =>
       )
       activityStore.createIndex('date', 'date')
 
-      // migrations
-      return migrate(lastVersion, currentVersion, transaction)
+      // migrations - not ran in test unless directly
+      if (process.env.NODE_ENV !== 'test') {
+        await migrate(lastVersion, currentVersion, transaction)
+      }
     },
   })
 

--- a/src/background/storage/index-db.js
+++ b/src/background/storage/index-db.js
@@ -1,0 +1,67 @@
+import { openDB } from 'idb'
+import {
+  DATABASE_NAME,
+  DATABASE_VERSION,
+  DATABASE_STORE,
+  LAST_ACTIVITY_TABLE,
+  ACTIVITY_NUMBER_KEY,
+} from '../../constants'
+import { set } from '../../lib/util'
+import { types } from './types'
+
+export const open = async () =>
+  openDB(DATABASE_NAME, DATABASE_VERSION, {
+    upgrade(db) {
+      db.createObjectStore(DATABASE_STORE)
+      const activityStore = db.createObjectStore(
+        LAST_ACTIVITY_TABLE,
+        {
+          keyPath: 'id',
+          autoIncrement: true,
+        }
+      )
+      activityStore.createIndex('date', 'date')
+    },
+  })
+
+export const database = open()
+
+export const createMethods = (db, store) => ({
+  async get(key) {
+    return (await db).get(store, key)
+  },
+  async set(key, val) {
+    return (await db).put(store, val, key)
+  },
+  async delete(key) {
+    return (await db).delete(store, key)
+  },
+  async clear() {
+    return (await db).clear(store)
+  },
+  async keys() {
+    return (await db).getAllKeys(store)
+  },
+})
+
+export const store = createMethods(database, DATABASE_STORE)
+
+export const addLatestActivity = async date => {
+  const db = await database
+  const activityNumber = (await store.get(ACTIVITY_NUMBER_KEY)) || 0
+  return db.add(LAST_ACTIVITY_TABLE, {
+    date,
+    activityNumber,
+  })
+}
+
+export default {
+  getters: types.reduce((accum, type) => {
+    set(accum, type, store.get)
+    return accum
+  }, {}),
+  setters: types.reduce((accum, type) => {
+    set(accum, type, store.set)
+    return accum
+  }, {}),
+}

--- a/src/background/storage/index-db.js
+++ b/src/background/storage/index-db.js
@@ -5,8 +5,10 @@ import {
   DATABASE_STORE,
   LAST_ACTIVITY_TABLE,
   ACTIVITY_NUMBER_KEY,
+  VALUE_CHANGED,
 } from '../../constants'
 import { set } from '../../lib/util'
+import { broadcaster } from './broadcast'
 import { types } from './types'
 
 export const open = async () =>
@@ -30,8 +32,10 @@ export const createMethods = (db, store) => ({
   async get(key) {
     return (await db).get(store, key)
   },
-  async set(key, val) {
-    return (await db).put(store, val, key)
+  async set(key, value) {
+    const ret = await (await db).put(store, value, key)
+    broadcaster.broadcast({ key, value, event: VALUE_CHANGED })
+    return ret
   },
   async delete(key) {
     return (await db).delete(store, key)

--- a/src/background/storage/index-db.test.js
+++ b/src/background/storage/index-db.test.js
@@ -1,0 +1,44 @@
+import {
+  LAST_ACTIVITY_TABLE,
+  ACTIVITY_NUMBER_KEY,
+} from '../../constants'
+import indexDBInterface, {
+  open,
+  database,
+  addLatestActivity,
+  store,
+} from './index-db'
+import { types } from './types'
+
+test('open should return a promise', () => {
+  expect(typeof open().then).toBe('function')
+})
+
+test('database to be a promise', () => {
+  expect(typeof database.then).toBe('function')
+})
+
+test('addLatestActivity should add an entry to indexDB', async () => {
+  const db = await database
+  const date = new Date()
+  await store.set(ACTIVITY_NUMBER_KEY, 1)
+  const added = await addLatestActivity(date)
+  expect(db.get(LAST_ACTIVITY_TABLE, added)).resolves.toEqual({
+    date,
+    activityNumber: 1,
+    id: added,
+  })
+})
+
+// NOTE: most other functionality of this module is tests like ./types.test.js
+test('localStorageInterface should have getters for all types', () => {
+  types.forEach(type => {
+    expect(typeof indexDBInterface.getters[type]).toBe('function')
+  })
+})
+
+test('localStorageInterface should have setters for all types', () => {
+  types.forEach(type => {
+    expect(typeof indexDBInterface.setters[type]).toBe('function')
+  })
+})

--- a/src/background/storage/index.js
+++ b/src/background/storage/index.js
@@ -1,20 +1,20 @@
 import statsModel from '../../model'
-import localStorage from './local-storage'
+import indexDB from './index-db'
 import { Storage } from './storage'
 
 export const storage = Storage.from({
   version: '1',
   model: statsModel,
-  storageInterface: localStorage,
+  storageInterface: indexDB,
 })
 
 // TODO: Think about breaking these out
 export const onGetStorage = async (key, callback) => {
   const value = await storage.get(key)
-  callback({ key, value })
+  return callback({ key, value })
 }
 
 export const onSetStorage = async (key, value, callback) => {
   await storage.set(key, value)
-  callback({ key, value })
+  return callback({ key, value })
 }

--- a/src/background/storage/index.test.js
+++ b/src/background/storage/index.test.js
@@ -1,21 +1,31 @@
-import { ALARM_KEY } from '../../constants'
+import { ALARM_KEY, DATABASE_STORE } from '../../constants'
+import { open, createMethods } from './index-db'
 import { onGetStorage, onSetStorage } from '.'
 
-test('onGetStorage should get data from localStorage', () => {
+let db
+let store
+
+beforeAll(async () => {
+  db = await open()
+  store = createMethods(db, DATABASE_STORE)
+})
+
+test('onGetStorage should get data from indexDB', async () => {
   expect.assertions(2)
-  localStorage.setItem(ALARM_KEY, true)
-  onGetStorage(ALARM_KEY, ({ key, value }) => {
+  await store.set(ALARM_KEY, true)
+  await onGetStorage(ALARM_KEY, ({ key, value }) => {
     expect(key).toBe(ALARM_KEY)
     expect(value).toBe(true)
   })
 })
 
-test('onSetStorage should set data from localStorage', () => {
+test('onSetStorage should set data in indexDB', async () => {
   expect.assertions(3)
-  localStorage.setItem(ALARM_KEY, false)
-  onSetStorage(ALARM_KEY, true, ({ key, value }) => {
+  await store.set(ALARM_KEY, false)
+  await onSetStorage(ALARM_KEY, true, async ({ key, value }) => {
     expect(key).toBe(ALARM_KEY)
     expect(value).toBe(true)
-    expect(localStorage.getItem(ALARM_KEY)).toBe('true')
+    const alarmKey = await store.get(ALARM_KEY)
+    expect(alarmKey).toBe(true)
   })
 })

--- a/src/background/storage/migrations/1.js
+++ b/src/background/storage/migrations/1.js
@@ -1,0 +1,42 @@
+import { DATABASE_STORE } from '../../../constants'
+import { set } from '../../../lib/util'
+import model from '../../../model'
+import localStorageInterface from '../local-storage'
+
+export const version1Migration = async (db, log) => {
+  log('Attempting to migrate from local storage to indexDB')
+  const keys = Object.keys(model)
+  const localStorageData = (await Promise.all(
+    keys.map(async key => {
+      const type = typeof model[key].type()
+      return [key, await localStorageInterface.getters[type](key)]
+    })
+  )).reduce((accum, [key, val]) => {
+    if (val !== null) {
+      set(accum, key, val)
+    }
+    return accum
+  }, {})
+  const localStorageKeys = Object.keys(localStorageData)
+  const hasData = Object.keys(localStorageData).length
+  if (!hasData) {
+    log('No data found migration complete')
+    return
+  }
+
+  try {
+    await localStorageKeys.reduce(
+      (promise, key) =>
+        promise.then(() =>
+          db.put(DATABASE_STORE, localStorageData[key], key)
+        ),
+      Promise.resolve()
+    )
+  } catch (e) {
+    log('Failed. Please contact support')
+    console.error(e)
+    return
+  }
+  log('Success removing old data')
+  localStorage.clear()
+}

--- a/src/background/storage/migrations/1.js
+++ b/src/background/storage/migrations/1.js
@@ -3,7 +3,7 @@ import { set } from '../../../lib/util'
 import model from '../../../model'
 import localStorageInterface from '../local-storage'
 
-export const version1Migration = async (db, log) => {
+export const version1Migration = async (transaction, log) => {
   log('Attempting to migrate from local storage to indexDB')
   const keys = Object.keys(model)
   const localStorageData = (await Promise.all(
@@ -28,7 +28,9 @@ export const version1Migration = async (db, log) => {
     await localStorageKeys.reduce(
       (promise, key) =>
         promise.then(() =>
-          db.put(DATABASE_STORE, localStorageData[key], key)
+          transaction
+            .objectStore(DATABASE_STORE)
+            .put(localStorageData[key], key)
         ),
       Promise.resolve()
     )
@@ -39,4 +41,5 @@ export const version1Migration = async (db, log) => {
   }
   log('Success removing old data')
   localStorage.clear()
+  await transaction.done
 }

--- a/src/background/storage/migrations/index.js
+++ b/src/background/storage/migrations/index.js
@@ -1,0 +1,28 @@
+import { version1Migration } from './1'
+
+const migrations = { 1: version1Migration }
+
+const logger = label => message => console.log(`${label}: ${message}`)
+const log = logger('Migration')
+
+export const migrate = (prevVersion, currentVersion, db) => {
+  const needMigration = prevVersion && prevVersion < currentVersion
+  const initialMigration = !prevVersion
+  log('Starting migration script')
+  log(
+    `Checking migration from version ${prevVersion} to ${currentVersion}`
+  )
+
+  if (initialMigration) {
+    log('Migration initial data')
+    return migrations[1](db, log)
+  }
+  if (needMigration) {
+    log('Migration needed')
+    return Promise.resolve()
+    // setup migrations to next version.
+    // const migationList = Array.from(migrations)
+  }
+  log('No migration needed or found')
+  return Promise.resolve(true)
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const ALARM_KEY = 'MINDFUL_ALARM' // also storage key
 export const HEARTBEAT = 'HEARTBEAT'
 
 // DB Keys
-export const DATABASE_NAME = 'MUJO - TEST'
+export const DATABASE_NAME = 'MUJO'
 export const DATABASE_STORE = 'STATS'
 export const DATABASE_VERSION = 1
 export const LAST_ACTIVITY_TABLE = 'LAST_ACTIVITY'

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,10 @@ export const PAGE_VIEWING_TIME = 'Page Viewing Time'
 export const DEEP_LINK_NEWTAB = 'Deep Link New Tab'
 export const RESET_USAGE = 'Reset Usage Stats'
 export const TRACK = 'Track'
+export const ADD_BROADCAST_TAB = 'Add Broadcast Tab'
+export const REMOVE_BROADCAST_TAB = 'Remove Broadcast Tab'
+export const VALUE_CHANGED = 'Value changed'
+
 // Getter, Setters for storage
 export const GET_STORAGE = 'GET_STORAGE'
 export const SET_STORAGE = 'SET_STORAGE'

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,12 @@ export const ALARM_DEFAULT_VALUE = true
 export const ALARM_KEY = 'MINDFUL_ALARM' // also storage key
 export const HEARTBEAT = 'HEARTBEAT'
 
+// DB Keys
+export const DATABASE_NAME = 'MUJO'
+export const DATABASE_STORE = 'STATS'
+export const DATABASE_VERSION = 1
+export const LAST_ACTIVITY_TABLE = 'LAST_ACTIVITY'
+
 // Storage keys
 export const TOP_SITES_KEY = 'TOP_SITES'
 export const TOP_SITES_USAGE_KEY = 'TOP_SITES_USAGE'

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const ALARM_KEY = 'MINDFUL_ALARM' // also storage key
 export const HEARTBEAT = 'HEARTBEAT'
 
 // DB Keys
-export const DATABASE_NAME = 'MUJO'
+export const DATABASE_NAME = 'MUJO - TEST'
 export const DATABASE_STORE = 'STATS'
 export const DATABASE_VERSION = 1
 export const LAST_ACTIVITY_TABLE = 'LAST_ACTIVITY'

--- a/src/hooks/use-storage.js
+++ b/src/hooks/use-storage.js
@@ -14,7 +14,11 @@ export const useStorage = key => {
 
   const updateFromStore = useCallback(async () => {
     const storageValue = await getStorage(key)
-    if (storageValue === null) return
+    const isUndefined = typeof storageValue === 'undefined'
+    const isNull = storageValue === null
+    if (isNull || isUndefined) {
+      return
+    }
     setState(storageValue)
   }, [key])
 

--- a/src/lib/__mocks__/extension.js
+++ b/src/lib/__mocks__/extension.js
@@ -3,6 +3,11 @@
 */
 import model from '../../model'
 
+const stampEvent = () => ({
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+})
+
 export const getStorageFn = async key => model[key].defaultValue
 export const setStorageFn = async (key, value) => value
 
@@ -15,9 +20,18 @@ export const alarms = {
   get: jest.fn(),
   create: jest.fn(),
   clear: jest.fn(),
+  onAlarm: stampEvent(),
 }
-export const notifications = { create: jest.fn(), clear: jest.fn() }
-export const tabs = { create: jest.fn() }
-export const webNavigation = {}
+export const notifications = {
+  create: jest.fn(),
+  clear: jest.fn(),
+  onClicked: stampEvent(),
+}
+export const tabs = {
+  create: jest.fn(),
+  onRemoved: stampEvent(),
+  sendMessage: jest.fn(),
+}
+export const webNavigation = { onCommited: stampEvent() }
 export const runtime = {}
 export const topSites = { get: jest.fn() }

--- a/src/lib/__mocks__/extension.js
+++ b/src/lib/__mocks__/extension.js
@@ -31,7 +31,9 @@ export const tabs = {
   create: jest.fn(),
   onRemoved: stampEvent(),
   sendMessage: jest.fn(),
+  executeScript: jest.fn(),
 }
-export const webNavigation = { onCommited: stampEvent() }
+export const permissions = { contains: jest.fn() }
+export const webNavigation = { onCommitted: stampEvent() }
 export const runtime = {}
 export const topSites = { get: jest.fn() }

--- a/src/lib/extension.js
+++ b/src/lib/extension.js
@@ -11,7 +11,6 @@ export const message = async (event, data) =>
   new Promise((resolve, reject) => {
     const payload = Object.assign({ event }, data || {})
     chrome.runtime.sendMessage(payload, (response = {}, ...args) => {
-      console.log([response], args)
       if (response.error) {
         reject(response.error)
         return

--- a/src/lib/extension.js
+++ b/src/lib/extension.js
@@ -10,7 +10,8 @@ import { promisifyObject } from './promisify'
 export const message = async (event, data) =>
   new Promise((resolve, reject) => {
     const payload = Object.assign({ event }, data || {})
-    chrome.runtime.sendMessage(payload, (response = {}) => {
+    chrome.runtime.sendMessage(payload, (response = {}, ...args) => {
+      console.log([response], args)
       if (response.error) {
         reject(response.error)
         return

--- a/src/lib/promisify.test.js
+++ b/src/lib/promisify.test.js
@@ -1,0 +1,47 @@
+import {
+  promisify,
+  promisifyNode,
+  promisifyObject,
+} from './promisify'
+
+test('promisify should resolve first callback arg', async () => {
+  const foo = (arg1, fn) => fn(arg1)
+  const bar = promisify(foo)
+  const result = await bar('baz')
+
+  expect(result).toBe('baz')
+})
+
+test('promisifyNode should resolve second callback arg', async () => {
+  const foo = (arg1, fn) => fn(null, arg1)
+  const bar = promisifyNode(foo)
+  const result = await bar('baz')
+
+  expect(result).toBe('baz')
+})
+
+test('promisifyNode should reject if it has a first arg', async () => {
+  const foo = (arg1, fn) => fn(new Error('foo'), arg1)
+  const bar = promisifyNode(foo)
+  let err
+  try {
+    await bar('baz')
+  } catch (e) {
+    err = e
+  }
+
+  expect(err.message).toBe('foo')
+})
+
+test('promisifyObject should promisify an object', async () => {
+  const foo = {
+    bar: fn => fn('bar'),
+    baz: (arg, fn) => fn('baz'),
+  }
+  const qux = promisifyObject(foo)
+  const barResult = await qux.bar()
+  const bazResult = await qux.baz('foo')
+
+  expect(barResult).toBe('bar')
+  expect(bazResult).toBe('baz')
+})


### PR DESCRIPTION
## Description

This changes our DB store to indexDB. It is a lot better to store things in and has better transactions. I really wanted to get something closer to a tabular DB for storing last active times. Also, IndexDB has the ability to get ranges which will come in handy when starting to analyze the last active times. IndexDB has some huge data limits so it will allow users to store huge amounts of rows.

<img width="536" alt="Screen Shot 2019-07-03 at 10 18 38 PM" src="https://user-images.githubusercontent.com/578259/60641560-270ee200-9de1-11e9-90d9-f152d8289324.png">

## ~~Still Needs~~

- [x] Some sort of observer for data that we can subscribe tabs to data keys and then send them updates. ( [For this](https://github.com/jcblw/Mujo-extension/blob/master/src/hooks/use-extension.js#L68-L69) )
- [x] Migrate over any local storage data.