### PR TITLE
Limit break timers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,6 +1349,16 @@
         "loader-utils": "^1.1.0"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-1.1.0.tgz",
+      "integrity": "sha512-piE/ceQoNf134FFVXBABDbttBJ8eLPD4eg7zIciVJv92RyvoIsBHCvvG8Vd4IG5pyuWYrkLsZTO8ucZBwa4twA==",
+      "requires": {
+        "@babel/runtime": "^7.4.2",
+        "@types/react": "^16.8.22",
+        "@types/react-test-renderer": "^16.8.2"
+      }
+    },
     "@tweenjs/tween.js": {
       "version": "17.4.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-17.4.0.tgz",
@@ -1418,10 +1428,32 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
       "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
     },
+    "@types/prop-types": {
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+    },
+    "@types/react": {
+      "version": "16.8.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
+      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.8.2.tgz",
+      "integrity": "sha512-cm42QR9S9V3aOxLh7Fh7PUqQ8oSfSdnSni30T7TiTmlKvE6aUlo+LhQAzjnZBPriD9vYmgG8MXI8UDK4Nfb7gg==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/core": "^10.0.14",
     "@jcblw/box": "^3.0.0",
     "@svgr/webpack": "4.1.0",
+    "@testing-library/react-hooks": "^1.1.0",
     "@tweenjs/tween.js": "^17.4.0",
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.6.0",

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import { Player } from './components/player'
 import { ScreenTime } from './components/screen-time'
 import { ToolTip } from './components/tool-tip'
 import { TopSites } from './components/top-sites'
+import { UpsellModal } from './components/upsell-modal'
 import { SCREEN_TIME_FEATURE } from './constants'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
@@ -45,6 +46,7 @@ const App = () => {
       appReady,
       selectedSegment,
       playerIsOpen,
+      upsellModal,
     },
     {
       setAlarmEnabled,
@@ -54,6 +56,7 @@ const App = () => {
       setBreakTimer,
       setSelectedSegment,
       setPlayerIsOpen,
+      setUpsellModal,
     },
   ] = useExtension()
   const theme = useTheme()
@@ -189,6 +192,15 @@ const App = () => {
           </Box>
         </>
       ) : null}
+      {upsellModal && (
+        <UpsellModal
+          context={upsellModal}
+          isOpen={true}
+          onRequestClose={() => {
+            setUpsellModal(null)
+          }}
+        />
+      )}
     </Box>
   )
 }

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -57,7 +57,10 @@ export const Modal = props => {
     'getStyles',
     'modalMaxHeight',
     'children',
-    'css'
+    'css',
+    'closeColor',
+    'color',
+    'background'
   )
   return (
     <ClassNames>
@@ -68,11 +71,11 @@ export const Modal = props => {
           className={css([
             ...results.styles,
             getModalContent({
-              background: theme.background,
-              color: theme.foreground,
+              background: props.background || theme.background,
+              color: props.color || theme.foreground,
               modalMaxHeight,
             }),
-            otherProps.css,
+            props.css,
           ])}
           overlayClassName={`mujo-modal ${css(
             getOverlayClass(theme.backgroundSecondary)
@@ -82,7 +85,7 @@ export const Modal = props => {
           <Close
             position="absolute"
             css={{ top: 24, right: 24 }}
-            fill={theme.foreground}
+            fill={props.closeColor || theme.foreground}
             onClick={props.onRequestClose}
           />
           {props.children}

--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -365,7 +365,7 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
     </div>
   </button>
   <div
-    className="css-17ah7x5"
+    className="css-1w4ofee"
     data-mujo={true}
     isOpen={true}
     onRequestClose={[Function]}
@@ -615,7 +615,7 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
     </div>
   </button>
   <div
-    className="css-17ah7x5"
+    className="css-1w4ofee"
     data-mujo={true}
     isOpen={true}
     onRequestClose={[Function]}
@@ -712,7 +712,29 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
       >
         <div
           className="css-i3jcei"
-        />
+        >
+          <div
+            className="css-j7qwjs"
+          >
+            <div
+              className="css-102g4jn"
+            >
+              <input
+                className="css-1ay9vb9"
+                id="break-timer"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <h4
+                className="css-30v94s"
+                color="color"
+                labelFor="break-timer"
+              >
+                Break Timer
+              </h4>
+            </div>
+          </div>
+        </div>
         <div
           className="css-wjp2bi"
         >

--- a/src/components/upsell-modal/__snapshots__/index.test.js.snap
+++ b/src/components/upsell-modal/__snapshots__/index.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpsellModal should match snapshot 1`] = `
+<div
+  className="css-1t7sqgn"
+  data-mujo={true}
+  isOpen={true}
+  outlineColor="saltBox"
+  overlayClassName="mujo-modal css-qcfpiy"
+  shouldCloseOnOverlayClick={true}
+>
+  <svg
+    className="css-1mv301s"
+    height={20}
+    position="absolute"
+    width={19}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      className="css-0"
+      d="
+        M9.778 6.864
+        l5.754-6.1
+        a2 2 0 1 1 2.91 2.746
+        l-5.914 6.268 5.913 6.269
+        a2 2 0 1 1-2.91 2.744
+        l-5.753-6.098-5.753 6.098
+        a2 2 0 1 1-2.91-2.744
+        l5.914-6.269L1.115 3.51
+        A2 2 0 1 1 4.025.765l5.753 6.099z
+        "
+      fill="mischka"
+      fillRule="nonzero"
+    />
+  </svg>
+  <div
+    className="css-ek4z02"
+    overflow="scroll"
+  >
+    <h2
+      className="css-1lzekp8"
+      color="color"
+    >
+      Mindful to the max
+    </h2>
+    <p
+      className="css-120ftwk"
+      color="color"
+    >
+      You have set the max number of break timers.
+    </p>
+  </div>
+  <div
+    className="css-qjrave"
+  />
+</div>
+`;

--- a/src/components/upsell-modal/index.js
+++ b/src/components/upsell-modal/index.js
@@ -1,0 +1,50 @@
+import { Box } from '@jcblw/box'
+import React from 'react'
+import { useTheme } from '../../hooks/use-theme'
+import { Button } from '../button'
+import { HeaderL, BodyL } from '../fonts'
+import { Modal } from '../modal'
+import { getModalData } from './modal-data'
+
+export const UpsellModal = ({ isOpen, onRequestClose, context }) => {
+  const { highlight } = useTheme()
+  const { title, description, button } = getModalData(context)
+  return (
+    <Modal
+      display="flex"
+      direction="column"
+      outlineColor={highlight}
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      padding="zero"
+      css={{
+        width: '35vw',
+        height: '60vh',
+        maxWidth: '35vw',
+        maxHeight: '60vh',
+      }}
+    >
+      <Box padding="l" flex="1" overflow="scroll">
+        {title && <HeaderL>{title}</HeaderL>}
+        {description && Array.isArray(description) ? (
+          description.map((paragraph, i) => (
+            <BodyL key={`paragraph-${i}`}>{paragraph}</BodyL>
+          ))
+        ) : (
+          <BodyL>{description}</BodyL>
+        )}
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="flexEnd"
+        flex="0"
+        paddingBottom="m"
+        paddingRight="l"
+      >
+        {button && (
+          <Button design={button.design || 'secondary'} {...button} />
+        )}
+      </Box>
+    </Modal>
+  )
+}

--- a/src/components/upsell-modal/index.test.js
+++ b/src/components/upsell-modal/index.test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { create } from 'react-test-renderer'
+import { MAX_BREAKTIMER_MODAL } from '../../constants'
+import { Button } from '../button'
+import { HeaderL, BodyL } from '../fonts'
+import { UpsellModal } from '.'
+
+test('UpsellModal should match snapshot', () => {
+  // Use break timer modal for snapshot
+  const context = { name: MAX_BREAKTIMER_MODAL, url: 'foo' }
+  const tree = create(
+    <UpsellModal isOpen={true} context={context} />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('UpsellModal should allow for custom contexts', () => {
+  const context = { title: 'foo', description: ['bar'] }
+  const { root } = create(
+    <UpsellModal isOpen={true} context={context} />
+  )
+  expect(root.findByType(HeaderL).props.children).toBe('foo')
+  expect(root.findByType(BodyL).props.children).toBe('bar')
+})
+
+test('UpsellModal should allow for clicks to buttons', done => {
+  expect.assertions(2)
+  const context = {
+    button: {
+      children: 'foo',
+      onClick: () => {
+        expect(true).toBe(true)
+        done()
+      },
+    },
+  }
+  const { root } = create(
+    <UpsellModal isOpen={true} context={context} />
+  )
+  const button = root.findByType(Button)
+  button.props.onClick()
+  expect(button.props.children).toBe('foo')
+})

--- a/src/components/upsell-modal/modal-data.js
+++ b/src/components/upsell-modal/modal-data.js
@@ -1,0 +1,33 @@
+import { SUBSCRIBE_FEATURE } from '../../constants'
+import { identity } from '../../lib/functional'
+
+const modals = {
+  breakTimerMax: ({ url, onClick }) => {
+    if (SUBSCRIBE_FEATURE) {
+      return {
+        title: 'Mindful to the max',
+        description: [
+          'You have set the max number of break timers.',
+          [
+            'To get access to unlimited break timers',
+            `and add a break timer for ${url}`,
+            'subscribe to Mujō.',
+          ].join(' '),
+        ],
+        button: {
+          children: 'Subscribe',
+          onClick,
+        },
+      }
+    }
+    return {
+      title: 'Mindful to the max',
+      description: ['You have set the max number of break timers.'],
+    }
+  },
+}
+
+export const getModalData = context => {
+  const modalData = modals[context.name] || identity
+  return modalData(context)
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ export const FOURTY_FIVE_MINUTES = MINUTE * 45
 export const HOUR = MINUTE * 60
 export const THREE_HOURS = HOUR * 3
 export const ALARM_DEFAULT_VALUE = true
+export const MAX_BREAKTIMERS = 5
 
 // ALARMS
 export const ALARM_KEY = 'MINDFUL_ALARM' // also storage key
@@ -44,6 +45,9 @@ export const SET_STORAGE = 'SET_STORAGE'
 export const SCREEN_TIME_FEATURE = true
 export const BREAK_TIMER_FEATURE = true
 export const SUBSCRIBE_FEATURE = false
+
+// Upsell modals
+export const MAX_BREAKTIMER_MODAL = 'breakTimerMax'
 
 // OPTIONAL permissions requested
 export const SCREEN_TIME_PERMISSIONS = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,7 +42,8 @@ export const SET_STORAGE = 'SET_STORAGE'
 
 // Feature Flags
 export const SCREEN_TIME_FEATURE = true
-export const BREAK_TIMER_FEATURE = false
+export const BREAK_TIMER_FEATURE = true
+export const SUBSCRIBE_FEATURE = true
 
 // OPTIONAL permissions requested
 export const SCREEN_TIME_PERMISSIONS = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,7 +43,7 @@ export const SET_STORAGE = 'SET_STORAGE'
 // Feature Flags
 export const SCREEN_TIME_FEATURE = true
 export const BREAK_TIMER_FEATURE = true
-export const SUBSCRIBE_FEATURE = true
+export const SUBSCRIBE_FEATURE = false
 
 // OPTIONAL permissions requested
 export const SCREEN_TIME_PERMISSIONS = {

--- a/src/hooks/use-extension.js
+++ b/src/hooks/use-extension.js
@@ -12,6 +12,8 @@ import {
   ACTIVITY_NUMBER_KEY,
   ADD_BROADCAST_TAB,
   VALUE_CHANGED,
+  MAX_BREAKTIMER_MODAL,
+  MAX_BREAKTIMERS,
 } from '../constants'
 import { toSiteInfo } from '../lib/aggregation'
 import {
@@ -114,9 +116,9 @@ export const useExtension = () => {
     const enabledTimers = Object.keys(nextBreakTimers).filter(
       key => nextBreakTimers[key].enabled
     )
-    if (enabledTimers.length > 5) {
+    if (enabledTimers.length > MAX_BREAKTIMERS) {
       setUpsellModal({
-        name: 'breakTimerMax',
+        name: MAX_BREAKTIMER_MODAL,
         url: shortURL(url),
         onClick: () => setUpsellModal(null),
       })
@@ -179,6 +181,7 @@ export const useExtension = () => {
       setSelectedSegment,
       setPlayerIsOpen,
       setUpsellModal,
+      updateBreakTimers,
     },
   ]
 }

--- a/src/hooks/use-extension.js
+++ b/src/hooks/use-extension.js
@@ -37,6 +37,7 @@ export const useExtension = () => {
   const [appReady, setAppReady] = useState(false)
   const [playerIsOpen, setPlayerIsOpen] = useState(false)
   const [selectedSegment, setSelectedSegment] = useState(null)
+  const [upsellModal, setUpsellModal] = useState(null)
   const [alarmEnabled, setAlarmEnabled] = useStorage(ALARM_KEY)
   const [topSites, setTopSites] = useStorage(TOP_SITES_KEY)
   const [siteTimes, setSiteTimes] = useStorage(SITE_TIME_KEY)
@@ -110,6 +111,17 @@ export const useExtension = () => {
       enabled,
     })
     const nextBreakTimers = create(breakTimers, url, nextBreakTimer)
+    const enabledTimers = Object.keys(nextBreakTimers).filter(
+      key => nextBreakTimers[key].enabled
+    )
+    if (enabledTimers.length > 5) {
+      setUpsellModal({
+        name: 'breakTimerMax',
+        url: shortURL(url),
+        onClick: () => setUpsellModal(null),
+      })
+      return
+    }
     updateBreakTimers(nextBreakTimers)
   }
 
@@ -155,6 +167,7 @@ export const useExtension = () => {
       selectedSegment,
       playerIsOpen,
       activityNumber,
+      upsellModal,
     },
     {
       setAlarmEnabled: setAlarmEnabledProxy,
@@ -165,6 +178,7 @@ export const useExtension = () => {
       setBreakTimer,
       setSelectedSegment,
       setPlayerIsOpen,
+      setUpsellModal,
     },
   ]
 }

--- a/src/hooks/use-extension.test.js
+++ b/src/hooks/use-extension.test.js
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import { MAX_BREAKTIMER_MODAL, BREAK_TIMERS_KEY } from '../constants'
+import model from '../model'
+import { useExtension } from './use-extension'
+
+test('the useExtension should return an array with two item', () => {
+  const { result } = renderHook(() => useExtension())
+  expect(result.current.length).toBe(2)
+})
+
+test('the useExtension should by default only allow 5 break timers', () => {
+  model[BREAK_TIMERS_KEY].defaultValue = {
+    foo: { enabled: true },
+    bar: { enabled: true },
+    baz: { enabled: true },
+    qux: { enabled: true },
+    foobar: { enabled: true },
+  }
+  const { result } = renderHook(() => useExtension())
+  const { setBreakTimer } = result.current[1]
+  act(() => {
+    setBreakTimer('https://bazqux.com', 1, true)
+  })
+  const { breakTimers, upsellModal } = result.current[0]
+  expect(Object.keys(breakTimers).length).toBe(5)
+  expect(upsellModal.name).toBe(MAX_BREAKTIMER_MODAL)
+  expect(upsellModal.url).toBe('bazqux.com')
+  model[BREAK_TIMERS_KEY].defaultValue = {}
+})


### PR DESCRIPTION
## Description

This is the start of feature sets that will only be available to subscribed members. This puts a limit on enabled break timers, right now you can get around it by adding data directly to the database, but it is 
not super easy to do that with indexDB so I am not too worried.

Subscription feature on.
<img width="300" alt="Screen Shot 2019-07-11 at 10 21 45 AM" src="https://user-images.githubusercontent.com/578259/61071356-bf9af880-a3c5-11e9-9ebe-236c22d8b3da.png">
Subscription feature off.
<img width="300" alt="Screen Shot 2019-07-11 at 10 20 52 AM" src="https://user-images.githubusercontent.com/578259/61071357-bf9af880-a3c5-11e9-94a1-2d218addb2aa.png">

## Changes 

* Adds Subscription feature flag
* Sets up break timer limit
* Adds a upsell modal ( can use for up-sell for enabling screen time )

## TODO

~~I need to add some test for the use-extension hook. It has none right now.~~