### PR TITLE
ButtonGroup Component.

### DIFF
--- a/src/components/button-group/__snapshots__/index.test.js.snap
+++ b/src/components/button-group/__snapshots__/index.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonGroup component matches snapshot 1`] = `
+<div
+  className="css-1xhj18k"
+>
+  <button
+    backgroundColor="outerSpace"
+    borderBottomLeftRadius="l"
+    borderBottomRightRadius="none"
+    borderTopLeftRadius="l"
+    borderTopRightRadius="none"
+    className="css-9nurzw"
+    color="mischka"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    outlineColor="saltBox"
+    position="relative"
+  >
+    Foo
+  </button>
+  <div
+    className="css-1yljtvz"
+  />
+  <button
+    backgroundColor="outerSpace"
+    borderBottomLeftRadius="none"
+    borderBottomRightRadius="l"
+    borderTopLeftRadius="none"
+    borderTopRightRadius="l"
+    className="css-9nurzw"
+    color="mischka"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    outlineColor="saltBox"
+    position="relative"
+  >
+    Bar
+  </button>
+</div>
+`;

--- a/src/components/button-group/index.js
+++ b/src/components/button-group/index.js
@@ -1,36 +1,36 @@
 import { Box } from '@jcblw/box'
 import { removeKeys } from '@jcblw/box/dist/lib/remove-keys'
 import React from 'react'
-
-// clone element pass props but add new props.
+import { Button } from '../button'
 
 export const ButtonGroup = props => {
   const childArr = React.Children.toArray(props.children)
   const otherProps = removeKeys(props, 'children')
   return (
     <Box display="flex" direction="row" {...otherProps}>
-      {childArr.map((child, i, arr) => {
-        const isFirst = i === 0
-        const isLast = i === arr.length - 1
-        const borderTopLeftRadius = isFirst ? 'l' : 'none'
-        const borderBottomLeftRadius = isFirst ? 'l' : 'none'
-        const borderTopRightRadius = isLast ? 'l' : 'none'
-        const borderBottomRightRadius = isLast ? 'l' : 'none'
-        const element = React.cloneElement(child, {
-          key: `el-${i}`,
-          borderRadius: 'none',
-          borderTopLeftRadius,
-          borderBottomLeftRadius,
-          borderTopRightRadius,
-          borderBottomRightRadius,
-        })
-        return (
-          <>
-            {element}
-            {isLast ? null : <Box css={{ width: '1px' }} />}
-          </>
-        )
-      })}
+      {childArr
+        .filter(child => child.type === Button)
+        .map((child, i, arr) => {
+          const isFirst = i === 0
+          const isLast = i === arr.length - 1
+          const borderTopLeftRadius = isFirst ? 'l' : 'none'
+          const borderBottomLeftRadius = isFirst ? 'l' : 'none'
+          const borderTopRightRadius = isLast ? 'l' : 'none'
+          const borderBottomRightRadius = isLast ? 'l' : 'none'
+          const element = React.cloneElement(child, {
+            borderRadius: 'none',
+            borderTopLeftRadius,
+            borderBottomLeftRadius,
+            borderTopRightRadius,
+            borderBottomRightRadius,
+          })
+          return (
+            <React.Fragment key={`el-${i}`}>
+              {element}
+              {isLast ? null : <Box css={{ width: '1px' }} />}
+            </React.Fragment>
+          )
+        })}
     </Box>
   )
 }

--- a/src/components/button-group/index.js
+++ b/src/components/button-group/index.js
@@ -1,0 +1,36 @@
+import { Box } from '@jcblw/box'
+import { removeKeys } from '@jcblw/box/dist/lib/remove-keys'
+import React from 'react'
+
+// clone element pass props but add new props.
+
+export const ButtonGroup = props => {
+  const childArr = React.Children.toArray(props.children)
+  const otherProps = removeKeys(props, 'children')
+  return (
+    <Box display="flex" direction="row" {...otherProps}>
+      {childArr.map((child, i, arr) => {
+        const isFirst = i === 0
+        const isLast = i === arr.length - 1
+        const borderTopLeftRadius = isFirst ? 'l' : 'none'
+        const borderBottomLeftRadius = isFirst ? 'l' : 'none'
+        const borderTopRightRadius = isLast ? 'l' : 'none'
+        const borderBottomRightRadius = isLast ? 'l' : 'none'
+        const element = React.cloneElement(child, {
+          key: `el-${i}`,
+          borderRadius: 'none',
+          borderTopLeftRadius,
+          borderBottomLeftRadius,
+          borderTopRightRadius,
+          borderBottomRightRadius,
+        })
+        return (
+          <>
+            {element}
+            {isLast ? null : <Box css={{ width: '1px' }} />}
+          </>
+        )
+      })}
+    </Box>
+  )
+}

--- a/src/components/button-group/index.js
+++ b/src/components/button-group/index.js
@@ -3,13 +3,19 @@ import { removeKeys } from '@jcblw/box/dist/lib/remove-keys'
 import React from 'react'
 import { Button } from '../button'
 
+const defaultSpacerStyles = { width: '1px' }
+
 export const ButtonGroup = props => {
+  const {
+    spacerStyles = defaultSpacerStyles,
+    childComponent = Button,
+  } = props
   const childArr = React.Children.toArray(props.children)
-  const otherProps = removeKeys(props, 'children')
+  const otherProps = removeKeys(props, 'children', 'spacerStyles')
   return (
     <Box display="flex" direction="row" {...otherProps}>
       {childArr
-        .filter(child => child.type === Button)
+        .filter(child => child.type === childComponent)
         .map((child, i, arr) => {
           const isFirst = i === 0
           const isLast = i === arr.length - 1
@@ -27,7 +33,7 @@ export const ButtonGroup = props => {
           return (
             <React.Fragment key={`el-${i}`}>
               {element}
-              {isLast ? null : <Box css={{ width: '1px' }} />}
+              {isLast ? null : <Box css={spacerStyles} />}
             </React.Fragment>
           )
         })}

--- a/src/components/button-group/index.test.js
+++ b/src/components/button-group/index.test.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { create } from 'react-test-renderer'
+import { Button } from '../button'
+import { ButtonGroup } from '.'
+
+test('ButtonGroup component matches snapshot', () => {
+  const tree = create(
+    <ButtonGroup>
+      <Button>Foo</Button>
+      <Button>Bar</Button>
+    </ButtonGroup>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/styles/utils.js
+++ b/src/styles/utils.js
@@ -52,7 +52,30 @@ export const position = {
 
 export const display = { table: css({ display: 'table' }) }
 
-export const borderRadius = { xs: css({ borderRadius: '4px' }) }
+const radius = {
+  xs: '4px',
+  s: '8px',
+  m: '16px',
+  l: '24px',
+}
+
+export const borderRadius = makeStyles('borderRadius', radius)
+export const borderTopLeftRadius = makeStyles(
+  'borderTopLeftRadius',
+  radius
+)
+export const borderBottomLeftRadius = makeStyles(
+  'borderBottomLeftRadius',
+  radius
+)
+export const borderTopRightRadius = makeStyles(
+  'borderTopRightRadius',
+  radius
+)
+export const borderBottomRightRadius = makeStyles(
+  'borderBottomRightRadius',
+  radius
+)
 
 export const layer = {
   0: css({ zIndex: 0 }),


### PR DESCRIPTION
## Purpose

This adds a button group components. This will be useful for a new tabbing system. All it essentially does is configures the child components to be styled to look like they are squished together. 

<img width="346" alt="Screen Shot 2019-07-30 at 11 30 08 AM" src="https://user-images.githubusercontent.com/578259/62155542-05a8f500-b2be-11e9-9a5e-07f8ea3b3d5f.png">

## Usage 

```jsx
...
<ButtonGroup>
  <Button>Foo</Button>
  <Button>Bar</Button>
</ButtonGroup>
...
```

## Still Needs

- [x] Tests! A snapshot will work for this.
- [ ] Filter of children to make sure they are `Button` Children. ( filter out and not fail )

