### PR TITLE
Turn on predictive break timers for everyone

### DIFF
--- a/src/components/background-app/break-alarm/index.js
+++ b/src/components/background-app/break-alarm/index.js
@@ -1,6 +1,10 @@
 import { useEffect, useCallback } from 'react'
 import { upsertAlarm } from '../../../background/alarm/util'
-import { ALARM_KEY, THREE_HOURS } from '../../../constants'
+import {
+  ALARM_KEY,
+  THREE_HOURS,
+  PREDICTED_BREAK_TIMES_FEATURE,
+} from '../../../constants'
 import { useHeartBeat } from '../../../hooks/use-heart-beat'
 import { useStorage } from '../../../hooks/use-storage-background'
 import { alarms } from '../../../lib/extension'
@@ -11,8 +15,9 @@ export const BreakAlarm = () => {
 
   // callbacks
   const addBreakAlarm = useCallback(() => {
+    if (PREDICTED_BREAK_TIMES_FEATURE) return
     const delayInMinutes = msToMinutes(THREE_HOURS)
-    return upsertAlarm(ALARM_KEY, { delayInMinutes })
+    upsertAlarm(ALARM_KEY, { delayInMinutes })
   }, [])
   const removeBreakAlarm = useCallback(() => {
     alarms.clear(ALARM_KEY)

--- a/src/constants.js
+++ b/src/constants.js
@@ -66,7 +66,7 @@ export const SET_STORAGE = 'SET_STORAGE'
 export const SCREEN_TIME_FEATURE = true
 export const BREAK_TIMER_FEATURE = true
 export const SUBSCRIBE_FEATURE = true
-export const PREDICTED_BREAK_TIMES_FEATURE = false
+export const PREDICTED_BREAK_TIMES_FEATURE = true
 
 // Upsell modals
 export const MAX_BREAKTIMER_MODAL = 'breakTimerMax'


### PR DESCRIPTION
## Description

Predictive break-timers has been in beta for a bit and a majority of the code has been running.  This just turns on the last of the functionality and pushes it to everyone for now. This might go back behind a flag in the future.