### PR TITLE
Plugin Resolver

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 public/buy.js
+src/mujo-plugins
+src/plugins/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 public/buy.js
-src/mujo-plugins
+src/mujo-plugins.js
 src/plugins/*

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# Plugins
+src/mujo-plugins.js
+src/plugins/*

--- a/.mujorc.yml
+++ b/.mujorc.yml
@@ -11,6 +11,8 @@
 
 name: Mujō - Be mindful of your time
 description: Mujō is a extension that reminds you not to over work yourself.
+plugins:
+  - mujo-plugin-breaktimer
 permissions:
   - tabs
   - webNavigation

--- a/config/paths.js
+++ b/config/paths.js
@@ -85,6 +85,9 @@ module.exports = {
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
+  inRepoPlugins: resolveApp('plugins'),
+  appPluginsJs: resolveModule(resolveApp, 'src/mujo-plugins'),
+  appPluginsDir: resolveApp('src/plugins'),
 }
 
 module.exports.moduleFileExtensions = moduleFileExtensions

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,10 +1,6 @@
 import 'fake-indexeddb/auto'
 import './src/i18n'
 
-import { toMatchImageSnapshot } from 'jest-image-snapshot'
-
-expect.extend({ toMatchImageSnapshot })
-
 jest.mock('./src/lib/extension')
 
 beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,20 +1253,6 @@
         "@babel/plugin-transform-typescript": "^7.3.2"
       }
     },
-    "@babel/register": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.5.5.tgz",
-      "integrity": "sha512-pdd5nNR+g2qDkXZlW1yRCWFlNrAn2PPdnZUB72zjX4l1Vv4fMRRLwyf+n/idFCLI1UgVGboUU8oVziwTBiyNKQ==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.0.0",
-        "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
-        "mkdirp": "^0.5.1",
-        "pirates": "^4.0.0",
-        "source-map-support": "^0.5.9"
-      }
-    },
     "@babel/runtime": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
@@ -10054,11 +10040,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
-    "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
-    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -12210,65 +12191,6 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
       "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
-    },
-    "jest-image-snapshot": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/jest-image-snapshot/-/jest-image-snapshot-2.9.0.tgz",
-      "integrity": "sha512-ih/DwdW2AWjQLgTZeaXDH1qMw7g346t6RUK+2KVGXX8c4tNpTinSKR3h059AWhFQGxlZpBZ/dds3DMigosUcdw==",
-      "requires": {
-        "chalk": "^1.1.3",
-        "get-stdin": "^5.0.1",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "pixelmatch": "^4.0.2",
-        "pngjs": "^3.3.3",
-        "rimraf": "^2.6.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
     },
     "jest-jasmine2": {
       "version": "24.9.0",
@@ -15000,14 +14922,6 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
-    "pixelmatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-      "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
-      "requires": {
-        "pngjs": "^3.0.0"
-      }
-    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -15068,11 +14982,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
-    },
-    "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "pnp-webpack-plugin": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Mujo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1251,6 +1251,20 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-transform-typescript": "^7.3.2"
+      }
+    },
+    "@babel/register": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.5.5.tgz",
+      "integrity": "sha512-pdd5nNR+g2qDkXZlW1yRCWFlNrAn2PPdnZUB72zjX4l1Vv4fMRRLwyf+n/idFCLI1UgVGboUU8oVziwTBiyNKQ==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.0.0",
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.1",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.9"
       }
     },
     "@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1770,6 +1770,14 @@
           "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
           "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5500,6 +5508,16 @@
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "cache-base": {
@@ -6658,6 +6676,16 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -7588,6 +7616,14 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -8229,6 +8265,16 @@
         "object-assign": "^4.0.1",
         "object-hash": "^1.1.4",
         "rimraf": "^2.6.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -9162,6 +9208,16 @@
             "klaw": "^1.0.0",
             "path-is-absolute": "^1.0.0",
             "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "jsonfile": {
@@ -9260,6 +9316,16 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -11162,6 +11228,14 @@
         "source-map": "^0.6.1"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12171,6 +12245,14 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "strip-ansi": {
@@ -14132,6 +14214,16 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -15724,6 +15816,14 @@
         "ws": "^6.1.0"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -16773,9 +16873,9 @@
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-test-renderer": "^16.9.0",
     "react-use-file-reader": "^1.0.0",
     "resolve": "1.12.0",
+    "rimraf": "^3.0.0",
     "semver": "6.3.0",
     "sourcemapped-stacktrace": "^1.1.11",
     "style-loader": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "is-wsl": "^2.1.0",
     "jest": "^24.9.0",
     "jest-environment-jsdom-fourteen": "0.1.0",
-    "jest-image-snapshot": "^2.9.0",
     "jest-resolve": "24.9.0",
     "jest-watch-typeahead": "^0.4.0",
     "ky": "^0.13.0",
@@ -104,7 +103,6 @@
     "last 3 Chrome versions"
   ],
   "devDependencies": {
-    "@babel/register": "^7.5.5",
     "change-case": "^3.1.0",
     "cosmiconfig": "^5.2.1",
     "gaze": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "build:dev": "NODE_ENV=development node scripts/build.js && npm run build:post",
     "build:beta": "BETA='true' node scripts/build.js && npm run build:post && npm run append:beta",
     "build:post": "npm run append:sw && npm run append:sm && npm run append:manifest",
-    "build": "PUBLIC_URL=./ node scripts/build.js && npm run build:post",
+    "prepend:plugins": "NODE_ENV=development node scripts/plugins-resolver",
+    "build": "npm run prepend:plugins && PUBLIC_URL=./ node scripts/build.js && npm run build:post",
     "append:sw": "cra-append-sw --mode replace --skip-compile ./public/service-worker.js",
     "append:sm": "node scripts/modify-source-maps.js",
     "append:manifest": "node scripts/create-manifest.js",
@@ -102,6 +103,7 @@
     "last 3 Chrome versions"
   ],
   "devDependencies": {
+    "@babel/register": "^7.5.5",
     "change-case": "^3.1.0",
     "cosmiconfig": "^5.2.1",
     "gaze": "^1.1.3",

--- a/plugins/mujo-plugin-breaktimer/index.js
+++ b/plugins/mujo-plugin-breaktimer/index.js
@@ -1,0 +1,5 @@
+import { useEffect, useCallback } from 'react'
+
+const BreakAlarm = () => null
+
+export default BreakAlarm

--- a/scripts/plugins-resolver.js
+++ b/scripts/plugins-resolver.js
@@ -1,0 +1,92 @@
+require('@babel/register')
+
+const fs = require('fs')
+const path = require('path')
+const { promisify } = require('util')
+const cosmiconfig = require('cosmiconfig')
+const paths = require('../config/paths')
+const pkg = require('../package.json')
+
+const stat = promisify(fs.stat)
+const write = promisify(fs.writeFile)
+const symlink = promisify(fs.symlink)
+
+const promiseSeq = async (fn, arr) => {
+  const resolves = []
+  await arr.reduce(
+    (promise, plugin, i) =>
+      promise.then(async () => {
+        const resolve = await fn(plugin, i)
+        resolves.push(resolve)
+        return Promise.resolve()
+      }),
+    Promise.resolve()
+  )
+  return resolves
+}
+
+const run = async () => {
+  const name = pkg.name.toLowerCase()
+  const explorer = cosmiconfig(name)
+  const { config } = await explorer.search()
+  const pluginFolders = config.plugins
+  const plugins = await promiseSeq(resolvePlugin, pluginFolders)
+  await promiseSeq(symlinkPlugin(pluginFolders), plugins)
+  await createPluginFile(pluginFolders)
+}
+
+const symlinkPlugin = plugins => async (pluginPath, i) => {
+  // TODO: symlink folder path into src/plugins/"plugin"
+  // this will allow use to build it into webpack bundles
+  // will fail if there is already a symlink
+  await symlink(
+    pluginPath,
+    path.resolve(paths.appPluginsDir, plugins[i])
+  )
+}
+
+const doesExist = async pluginPath => {
+  try {
+    await stat(pluginPath)
+    return true
+  } catch (e) {
+    // will error if does not exist
+  }
+  return false
+}
+
+const createPluginFile = async plugins => {
+  const content = `module.exports = [${plugins
+    .map(
+      plugin =>
+        `require('${path.resolve(
+          paths.appPluginsDir,
+          plugin
+        )}').default`
+    )
+    .join(',\n')}]`
+
+  await write(paths.appPluginsJs, content)
+}
+
+const resolvePlugin = async pluginName => {
+  const nodeModulePath = path.resolve(
+    paths.appNodeModules,
+    pluginName
+  )
+  const isInNodeModule = await doesExist(
+    path.resolve(paths.appNodeModules, pluginName)
+  )
+  const inRepoPath = path.resolve(paths.inRepoPlugins, pluginName)
+  const isInRepo = await doesExist(inRepoPath)
+  const exists = isInNodeModule || isInRepo
+  if (!exists) {
+    throw new TypeError(`Plugin "${pluginName}" does not exist`)
+  }
+  // TODO we will eventually need to require the component in node
+  // to pull off any values for the manifest
+  console.log({ isInRepo, isInNodeModule })
+  return isInRepo ? inRepoPath : nodeModulePath
+}
+
+run()

--- a/scripts/plugins-resolver.js
+++ b/scripts/plugins-resolver.js
@@ -88,9 +88,8 @@ const resolvePlugin = async pluginName => {
   if (!exists) {
     throw new TypeError(`Plugin "${pluginName}" does not exist`)
   }
-  // TODO we will eventually need to require the component in node
-  // to pull off any values for the manifest
-  console.log({ isInRepo, isInNodeModule })
+
+  // TODO: check repo for config file to be able to add in permissions
   return isInRepo ? inRepoPath : nodeModulePath
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,6 @@ import { TopSites } from './components/top-sites'
 import { SCREEN_TIME_FEATURE, TRANSLATION_FILE } from './constants'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
-import { getPlugins } from './plugins'
 import { colors } from './styles/colors'
 import * as utilStyles from './styles/utils'
 import './i18n'
@@ -40,7 +39,6 @@ const factorMin = size => Math.max(size, DEFAULT_SIZE)
 const getFactor = x => factorMin(factor(x))
 
 const App = () => {
-  console.log(getPlugins())
   const {
     topSites,
     activityNumber,

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ import { TopSites } from './components/top-sites'
 import { SCREEN_TIME_FEATURE, TRANSLATION_FILE } from './constants'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
+import { getPlugins } from './plugins'
 import { colors } from './styles/colors'
 import * as utilStyles from './styles/utils'
 import './i18n'
@@ -39,6 +40,7 @@ const factorMin = size => Math.max(size, DEFAULT_SIZE)
 const getFactor = x => factorMin(factor(x))
 
 const App = () => {
+  console.log(getPlugins())
   const {
     topSites,
     activityNumber,

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,0 +1,11 @@
+export const getPlugins = () => {
+  let plugins
+  try {
+    /* eslint-disable-next-line global-require */
+    plugins = require('./mujo-plugins')
+  } catch (e) {
+    console.error('Error loading plugins', e)
+    plugins = []
+  }
+  return plugins
+}


### PR DESCRIPTION
## Description 

This is the start of a plugin resolver it does do quite everything needed for a full plugin resolver but this should give us 90% of what we need.

This essentially trys to resolve a plugin in the config to either a node module or a local plugin. Then it generates a file that requires all these files in an allows another script to require in all these imported plugins. Right now it will fail if one plugin fails to resolve. The plugins do not have functionality but that is because we need to start building out the plugins hooks/and components.

## Things this does not have.

Ability to add permissions to manifest file. There are probably some edge cases I am missing. Essentially I need to require a file build time right now to add permissions. I might change the spec to make this easier. Eg require a json file from the plugin for permissions and maybe translations.