### PR TITLE
New Tabbing

### DIFF
--- a/.mujorc.yml
+++ b/.mujorc.yml
@@ -59,7 +59,6 @@ contentSecurityPolicy:
     - "'self'"
     - https://www.google-analytics.com
     - chrome://favicon
-    - https://xn--muj-sxa.com
     - https://getmujo.com
   connectSrc:
     - https://getmujo.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -2482,9 +2482,9 @@
       "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
     },
     "@mujo/plugins": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.1.tgz",
-      "integrity": "sha512-vXNPrG6I1tUnuvUnqrmRF98bWth8uwb3qnd5xRxZFJmdWlswSAqT7vzok0l0YdwIrHkhmU/2ab+2PmwKTZaXZw=="
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.2.tgz",
+      "integrity": "sha512-InnYiE15cCpsW7rGVDOqdUX0TsvWYe1Qa9gYFvtlYGvGkM4nlgublNRa2DK/s6U/8N8d6E52vWB+xMMjIJ32eQ=="
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2482,9 +2482,9 @@
       "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
     },
     "@mujo/plugins": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.2.tgz",
-      "integrity": "sha512-InnYiE15cCpsW7rGVDOqdUX0TsvWYe1Qa9gYFvtlYGvGkM4nlgublNRa2DK/s6U/8N8d6E52vWB+xMMjIJ32eQ=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.5.tgz",
+      "integrity": "sha512-kcfR5Hpjrcx0DcHBMPJDkYfZ5N81qLA2fxU5H4/1YXVSdYJlhgLV8uqYxZWDtooQGAs7qjonWVz4LcIFuw7fmQ=="
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
@@ -4522,15 +4522,87 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA=="
     },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
@@ -4547,10 +4619,54 @@
       "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
     },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
@@ -4775,10 +4891,26 @@
         }
       }
     },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-add-react-displayname": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
       "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U="
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.2.0",
@@ -4931,10 +5063,287 @@
         "recast": "^0.14.7"
       }
     },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
@@ -4969,6 +5378,26 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+          "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+          "requires": {
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
+          }
+        }
+      }
+    },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
@@ -4997,10 +5426,72 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
     },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
       "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
     },
     "babel-preset-jest": {
       "version": "24.9.0",
@@ -5234,6 +5725,77 @@
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2482,9 +2482,9 @@
       "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
     },
     "@mujo/plugins": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.5.tgz",
-      "integrity": "sha512-kcfR5Hpjrcx0DcHBMPJDkYfZ5N81qLA2fxU5H4/1YXVSdYJlhgLV8uqYxZWDtooQGAs7qjonWVz4LcIFuw7fmQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.6.tgz",
+      "integrity": "sha512-n5nKLF9OAErR2y3Eu/cZ1bYpadaBGzi+R3WjDl//opvOKVwzhifDSj7pzWUqkKiyR4xijK/ggIrBSj1t9OLcrw=="
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
@@ -4522,87 +4522,15 @@
         "resolve": "^1.12.0"
       }
     },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA=="
     },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
@@ -4619,54 +4547,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
     },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
@@ -4891,26 +4775,10 @@
         }
       }
     },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
     "babel-plugin-add-react-displayname": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
       "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U="
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.2.0",
@@ -5063,287 +4931,10 @@
         "recast": "^0.14.7"
       }
     },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-        },
-        "regexpu-core": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-          "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-          "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
-          }
-        },
-        "regjsgen": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-        },
-        "regjsparser": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-          "requires": {
-            "jsesc": "~0.5.0"
-          }
-        }
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
@@ -5378,26 +4969,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "requires": {
-        "regenerator-transform": "^0.10.0"
-      },
-      "dependencies": {
-        "regenerator-transform": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-          "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-          "requires": {
-            "babel-runtime": "^6.18.0",
-            "babel-types": "^6.19.0",
-            "private": "^0.1.6"
-          }
-        }
-      }
-    },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
@@ -5426,72 +4997,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
     },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
       "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
-    },
-    "babel-preset-env": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "3.2.8",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-          "requires": {
-            "caniuse-lite": "^1.0.30000844",
-            "electron-to-chromium": "^1.3.47"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "babel-preset-jest": {
       "version": "24.9.0",
@@ -5725,77 +5234,6 @@
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-        }
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2476,6 +2476,11 @@
         "prettier": "^1.18.2"
       }
     },
+    "@mujo/ingress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mujo/ingress/-/ingress-0.1.0.tgz",
+      "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,6 +2481,11 @@
       "resolved": "https://registry.npmjs.org/@mujo/ingress/-/ingress-0.1.0.tgz",
       "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
     },
+    "@mujo/plugins": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mujo/plugins/-/plugins-0.0.1.tgz",
+      "integrity": "sha512-vXNPrG6I1tUnuvUnqrmRF98bWth8uwb3qnd5xRxZFJmdWlswSAqT7vzok0l0YdwIrHkhmU/2ab+2PmwKTZaXZw=="
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mujo/box": "^3.0.1",
     "@mujo/eslint-config": "^1.0.4",
     "@mujo/ingress": "^0.1.0",
-    "@mujo/plugins": "0.0.1",
+    "@mujo/plugins": "0.0.2",
     "@sentry/browser": "^5.6.3",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@emotion/core": "^10.0.17",
     "@mujo/box": "^3.0.1",
     "@mujo/eslint-config": "^1.0.4",
+    "@mujo/ingress": "^0.1.0",
     "@sentry/browser": "^5.6.3",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mujo/box": "^3.0.1",
     "@mujo/eslint-config": "^1.0.4",
     "@mujo/ingress": "^0.1.0",
-    "@mujo/plugins": "0.0.3",
+    "@mujo/plugins": "0.0.6",
     "@sentry/browser": "^5.6.3",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@mujo/box": "^3.0.1",
     "@mujo/eslint-config": "^1.0.4",
     "@mujo/ingress": "^0.1.0",
+    "@mujo/plugins": "0.0.1",
     "@sentry/browser": "^5.6.3",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mujo/box": "^3.0.1",
     "@mujo/eslint-config": "^1.0.4",
     "@mujo/ingress": "^0.1.0",
-    "@mujo/plugins": "0.0.2",
+    "@mujo/plugins": "0.0.3",
     "@sentry/browser": "^5.6.3",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",
@@ -22,7 +22,6 @@
     "@tweenjs/tween.js": "^17.4.0",
     "babel-eslint": "10.0.3",
     "babel-jest": "^24.9.0",
-    "babel-loader": "^8.0.6",
     "babel-plugin-named-asset-import": "^0.3.3",
     "babel-preset-react-app": "^9.0.1",
     "camelcase": "^5.2.0",
@@ -105,6 +104,7 @@
     "last 3 Chrome versions"
   ],
   "devDependencies": {
+    "babel-loader": "^8.0.6",
     "change-case": "^3.1.0",
     "cosmiconfig": "^5.2.1",
     "gaze": "^1.1.3",

--- a/public/index.html
+++ b/public/index.html
@@ -17,16 +17,6 @@
       }
     </style>
     <script src="./buy.js"></script>
-    <!-- <link rel="manifest" href="/manifest.json"> -->
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>New Tab</title>
   </head>
   <body>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,7 +1,7 @@
 const ICONCACHE = 'icon-cache-1'
 
 // White list icon domain
-const WHITELISTED_DOMAIN = 'https://xn--muj-sxa.com/'
+const WHITELISTED_DOMAIN = 'https://getmujo.com/'
 
 const onCachableRequest = async event => {
   const cachedResponse = await caches.match(event.request)
@@ -33,7 +33,7 @@ self.addEventListener('activate', () => {
 self.addEventListener('fetch', event => {
   // Skip cross-origin requests, like those for Google Analytics.
   const { url } = event.request
-  if (url.startsWith(WHITELISTED_DOMAIN)) {
+  if (url.startsWith(`${WHITELISTED_DOMAIN}/api/icon`)) {
     event.respondWith(onCachableRequest(event))
   }
 })

--- a/src/app.js
+++ b/src/app.js
@@ -1,14 +1,11 @@
 import { css, Global } from '@emotion/core'
 import { Box, styleGuide } from '@mujo/box'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
-import { Button } from './components/button'
-import { Span, Sup } from './components/fonts'
 import { Header } from './components/header'
 import { InfoModal } from './components/info-modal'
 import { ScreenTime } from './components/screen-time'
+import { Tabs, TabTarget } from './components/tabs'
 import { TopSites } from './components/top-sites'
-import { SCREEN_TIME_FEATURE, TRANSLATION_FILE } from './constants'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
 import { colors } from './styles/colors'
@@ -40,21 +37,12 @@ const getFactor = x => factorMin(factor(x))
 
 const App = () => {
   const {
-    topSites,
     activityNumber,
-    showTopSites,
-    siteTimesAndTimers,
     appReady,
-    selectedSegment,
     playerIsOpen,
     upsellModal,
     settings,
-    screenTime,
-    updateSitesUsed,
     resetUsage,
-    updateShowTopSites,
-    setBreakTimer,
-    setSelectedSegment,
     setPlayerIsOpen,
     setUpsellModal,
     breathAmount,
@@ -62,9 +50,7 @@ const App = () => {
   const theme = useTheme()
   const { background } = theme
   const logoSize = getFactor(activityNumber)
-  const toggleHandle = (fn, value) => () => fn(!value)
   const bg = bodyBackgrounds[background] || bodyBackgrounds.outerSpace
-  const { t } = useTranslation(TRANSLATION_FILE)
 
   return (
     <Box
@@ -97,20 +83,7 @@ const App = () => {
             setUpsellModal={setUpsellModal}
           />
           <Box flex="1" />
-          {!SCREEN_TIME_FEATURE || showTopSites ? (
-            <TopSites
-              topSites={topSites}
-              updateSitesUsed={updateSitesUsed}
-            />
-          ) : (
-            <ScreenTime
-              data={siteTimesAndTimers}
-              setBreakTimer={setBreakTimer}
-              selectedSegment={selectedSegment}
-              setSelectedSegment={setSelectedSegment}
-              permissions={screenTime}
-            />
-          )}
+          <TabTarget />
           <Box flex="1" />
           <Box
             display="flex"
@@ -128,31 +101,13 @@ const App = () => {
               direction="row"
               marginBottom="m"
             >
-              {SCREEN_TIME_FEATURE && (
-                <Button
-                  whiteSpace="nowrap"
-                  design={theme.buttonStyle}
-                  onClick={toggleHandle(
-                    updateShowTopSites,
-                    showTopSites
-                  )}
-                  alt={
-                    <Span>
-                      Toggle view between Screen Time <Sup>BETA</Sup>{' '}
-                      and top sites
-                    </Span>
-                  }
-                >
-                  {showTopSites
-                    ? t('show-screen-time')
-                    : t('show-top-sites')}
-                </Button>
-              )}
+              <Tabs />
             </Box>
           </Box>
         </>
       ) : null}
-
+      <ScreenTime />
+      <TopSites />
       <InfoModal
         zIndex="1000"
         changeModal={setUpsellModal}

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { Header } from './components/header'
 import { InfoModal } from './components/info-modal'
 import { ScreenTime } from './components/screen-time'
-import { Tabs, TabTarget } from './components/tabs'
+import { Tabs, TabsTarget } from './components/tabs'
 import { TopSites } from './components/top-sites'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
@@ -83,7 +83,7 @@ const App = () => {
             setUpsellModal={setUpsellModal}
           />
           <Box flex="1" />
-          <TabTarget />
+          <TabsTarget />
           <Box flex="1" />
           <Box
             display="flex"

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,13 @@
 import { css, Global } from '@emotion/core'
 import { Box, styleGuide } from '@mujo/box'
+import { IngressTarget } from '@mujo/ingress'
 import React from 'react'
 import { Header } from './components/header'
 import { InfoModal } from './components/info-modal'
 import { ScreenTime } from './components/screen-time'
-import { Tabs, TabsTarget } from './components/tabs'
+import { Tabs } from './components/tabs'
 import { TopSites } from './components/top-sites'
+import { TABS_TARGET } from './constants'
 import { useExtension } from './hooks/use-extension'
 import { useTheme } from './hooks/use-theme'
 import { colors } from './styles/colors'
@@ -83,24 +85,18 @@ const App = () => {
             setUpsellModal={setUpsellModal}
           />
           <Box flex="1" />
-          <TabsTarget />
+          <IngressTarget id={TABS_TARGET} />
           <Box flex="1" />
           <Box
             display="flex"
             flex={0}
-            paddingTop="m"
             alignItems="center"
             textAlign="center"
             justifyContent="center"
             layer="3"
             position="relative"
           >
-            <Box
-              flex={0}
-              display="flex"
-              direction="row"
-              marginBottom="m"
-            >
+            <Box flex={0} display="flex" direction="row">
               <Tabs />
             </Box>
           </Box>

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -2,12 +2,15 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import ReactTestRenderer from 'react-test-renderer'
 import App from './app'
+import { NTPPluginProvider } from './components/plugin-provider'
 import { ExtensionProvider } from './hooks/use-extension'
 import { SubscriptionProvider } from './hooks/use-subscription'
 
 const Wrapper = ({ children }) => (
   <SubscriptionProvider>
-    <ExtensionProvider>{children}</ExtensionProvider>
+    <ExtensionProvider>
+      <NTPPluginProvider>{children}</NTPPluginProvider>
+    </ExtensionProvider>
   </SubscriptionProvider>
 )
 

--- a/src/components/fav-button/index.js
+++ b/src/components/fav-button/index.js
@@ -23,7 +23,7 @@ export const FavButton = props => {
   const encodedURL = encodeURIComponent(props.url)
   const { t } = useTranslation(TRANSLATION_FILE)
   const iconUrl = isServer
-    ? `https://mujō.com/api/icon?site=${encodedURL}`
+    ? `https://getmujo.com/api/icon?site=${encodedURL}`
     : `chrome://favicon/${props.url}`
   const { background } = useTheme()
 
@@ -52,8 +52,8 @@ export const FavButton = props => {
           setIsLoaded(true)
         }}
         src={iconUrl}
-        width="16px"
-        height="16px"
+        width="m"
+        height="m"
         alt={`${props.title}`}
         {...imageStyles}
         {...(isLoaded ? loadedStyles : {})}

--- a/src/components/fav-rows/index.js
+++ b/src/components/fav-rows/index.js
@@ -26,6 +26,10 @@ export const FavRows = ({ items, updateSitesUsed }) => {
           display="flex"
           direction="column"
           padding="s"
+          maxWidth="xxl"
+          maxHeight="xxl"
+          height="xxl"
+          width="xxl"
         >
           {column.map(item => (
             <FavButton

--- a/src/components/plugin-provider/index.js
+++ b/src/components/plugin-provider/index.js
@@ -1,0 +1,17 @@
+import { PluginProvider as Provider } from '@mujo/plugins'
+import React from 'react'
+import * as constants from '../../constants'
+import { useExtension } from '../../hooks/use-extension'
+import * as extension from '../../lib/extension'
+
+export const NTPPluginProvider = ({ children }) => {
+  const { pushTab, currentTab, removeTab } = useExtension()
+  const tabbing = { pushTab, removeTab, currentTab }
+  const value = {
+    env: 'ntp',
+    extension,
+    constants,
+    tabbing,
+  }
+  return <Provider value={value}>{children}</Provider>
+}

--- a/src/components/plugin-provider/index.js
+++ b/src/components/plugin-provider/index.js
@@ -4,14 +4,15 @@ import * as constants from '../../constants'
 import { useExtension } from '../../hooks/use-extension'
 import * as extension from '../../lib/extension'
 
+// NOTE we use a proxy to allow for access to `useExtension`
 export const NTPPluginProvider = ({ children }) => {
   const { pushTab, currentTab, removeTab } = useExtension()
-  const tabbing = { pushTab, removeTab, currentTab }
-  const value = {
+  const tabs = { pushTab, removeTab, currentTab }
+  const props = {
     env: 'ntp',
     extension,
     constants,
-    tabbing,
+    tabs,
   }
-  return <Provider value={value}>{children}</Provider>
+  return <Provider {...props}>{children}</Provider>
 }

--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -233,7 +233,6 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
     className="css-0"
   >
     <svg
-      className="css-0"
       height="250"
       width="600"
       xmlns="http://www.w3.org/2000/svg"
@@ -472,7 +471,6 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
     className="css-0"
   >
     <svg
-      className="css-0"
       height="250"
       width="600"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/screen-time/__snapshots__/index.test.js.snap
+++ b/src/components/screen-time/__snapshots__/index.test.js.snap
@@ -233,8 +233,9 @@ exports[`ScreenTime should match snapshot with a grouped selected segment 1`] = 
     className="css-0"
   >
     <svg
-      height="250"
-      width="600"
+      className="css-0"
+      height="250px"
+      width="600px"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -471,8 +472,9 @@ exports[`ScreenTime should match snapshot with a selected segment 1`] = `
     className="css-0"
   >
     <svg
-      height="250"
-      width="600"
+      className="css-0"
+      height="250px"
+      width="600px"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/src/components/screen-time/index.js
+++ b/src/components/screen-time/index.js
@@ -1,4 +1,5 @@
 import { Box } from '@mujo/box'
+import { Tab } from '@mujo/plugins'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TRANSLATION_FILE } from '../../constants'
@@ -8,7 +9,6 @@ import { siteTimeToChartData } from '../../lib/aggregation'
 import { HeaderS, Sup, BodyS } from '../fonts'
 import { Graph } from '../graph'
 import { Switch } from '../switch'
-import { TabContent } from '../tabs'
 import { ToolTip } from '../tool-tip'
 import { Modal } from './modal'
 import { NotEnoughData, hasEnoughData } from './not-enough-data'
@@ -35,7 +35,7 @@ export const ScreenTime = () => {
   const showGraph = hasEnoughData(graphData, data)
   const status = hasPermission ? 'enabled' : 'disabled'
   return (
-    <TabContent name="Screen Time">
+    <Tab name="Screen Time">
       <Box
         flex="1"
         display="flex"
@@ -109,7 +109,7 @@ export const ScreenTime = () => {
           setBreakTimer={setBreakTimer}
         />
       </Box>
-    </TabContent>
+    </Tab>
   )
 }
 

--- a/src/components/screen-time/index.js
+++ b/src/components/screen-time/index.js
@@ -35,7 +35,7 @@ export const ScreenTime = () => {
   const showGraph = hasEnoughData(graphData, data)
   const status = hasPermission ? 'enabled' : 'disabled'
   return (
-    <Tab name="Screen Time">
+    <Tab name={t('screen-time')}>
       <Box
         flex="1"
         display="flex"

--- a/src/components/screen-time/index.js
+++ b/src/components/screen-time/index.js
@@ -2,23 +2,26 @@ import { Box } from '@mujo/box'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TRANSLATION_FILE } from '../../constants'
+import { useExtension } from '../../hooks/use-extension'
 import { useTheme } from '../../hooks/use-theme'
 import { siteTimeToChartData } from '../../lib/aggregation'
 import { HeaderS, Sup, BodyS } from '../fonts'
 import { Graph } from '../graph'
 import { Switch } from '../switch'
+import { TabContent } from '../tabs'
 import { ToolTip } from '../tool-tip'
 import { Modal } from './modal'
 import { NotEnoughData, hasEnoughData } from './not-enough-data'
 import { reduceSegmentToUrls } from './reducer'
 
-export const ScreenTime = ({
-  data,
-  setBreakTimer,
-  selectedSegment,
-  setSelectedSegment,
-  permissions = {},
-}) => {
+export const ScreenTime = () => {
+  const {
+    siteTimesAndTimers: data,
+    setBreakTimer,
+    selectedSegment,
+    setSelectedSegment,
+    screenTime: permissions,
+  } = useExtension()
   const { t } = useTranslation(TRANSLATION_FILE)
   const [toolTipOpen, setToolTipOpen] = useState(false)
   const {
@@ -32,79 +35,81 @@ export const ScreenTime = ({
   const showGraph = hasEnoughData(graphData, data)
   const status = hasPermission ? 'enabled' : 'disabled'
   return (
-    <Box
-      flex="1"
-      display="flex"
-      direction="column"
-      justifyContent="center"
-      alignItems="center"
-      textAlign="center"
-      position="relative"
-      layer="1"
-    >
-      <HeaderS
+    <TabContent name="Screen Time">
+      <Box
+        flex="1"
+        display="flex"
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        textAlign="center"
         position="relative"
-        cursor="pointer"
-        color={foreground}
-        onMouseLeave={() => setToolTipOpen(false)}
-        onMouseEnter={() => setToolTipOpen(true)}
+        layer="1"
       >
-        {t('screen-time')} <Sup>{t('beta')}</Sup>
-        <ToolTip isOpen={toolTipOpen}>
-          {t('screen-time-explain')}
-        </ToolTip>
-      </HeaderS>
-      {showGraph ? (
-        <Graph
-          data={graphData}
-          width={600}
-          height={275}
-          strokeWidth={16}
-          textFill={foreground}
-          stroke={highlight}
-          spacingAngle={16}
-          strokeLinecap="round"
-          radius={100}
-          selected={selectedSegment}
-          selectedStroke={foreground}
-          onSegmentClick={seg =>
-            setSelectedSegment(reduceSegmentToUrls(seg))
-          }
-        />
-      ) : (
-        <NotEnoughData />
-      )}
-      <Box display="flex" direction="row">
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
+        <HeaderS
+          position="relative"
+          cursor="pointer"
+          color={foreground}
+          onMouseLeave={() => setToolTipOpen(false)}
+          onMouseEnter={() => setToolTipOpen(true)}
         >
-          <Switch
-            onChange={() => {
-              if (hasPermission) {
-                removePermissions()
-              } else {
-                requestPermissions()
-              }
-            }}
-            value={hasPermission}
+          {t('screen-time')} <Sup>{t('beta')}</Sup>
+          <ToolTip isOpen={toolTipOpen}>
+            {t('screen-time-explain')}
+          </ToolTip>
+        </HeaderS>
+        {showGraph ? (
+          <Graph
+            data={graphData}
+            width={600}
+            height={275}
+            strokeWidth={16}
+            textFill={foreground}
+            stroke={highlight}
+            spacingAngle={16}
+            strokeLinecap="round"
+            radius={100}
+            selected={selectedSegment}
+            selectedStroke={foreground}
+            onSegmentClick={seg =>
+              setSelectedSegment(reduceSegmentToUrls(seg))
+            }
           />
+        ) : (
+          <NotEnoughData />
+        )}
+        <Box display="flex" direction="row">
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Switch
+              onChange={() => {
+                if (hasPermission) {
+                  removePermissions()
+                } else {
+                  requestPermissions()
+                }
+              }}
+              value={hasPermission}
+            />
+          </Box>
+          <BodyS flex="1" paddingLeft="m">
+            {t('screen-time-status', { status })}
+          </BodyS>
         </Box>
-        <BodyS flex="1" paddingLeft="m">
-          {t('screen-time-status', { status })}
-        </BodyS>
-      </Box>
 
-      <Modal
-        isOpen={!!selectedSegment}
-        theme={theme}
-        setSelectedSegment={setSelectedSegment}
-        selectedSegment={selectedSegment}
-        allSegments={graphData}
-        setBreakTimer={setBreakTimer}
-      />
-    </Box>
+        <Modal
+          isOpen={!!selectedSegment}
+          theme={theme}
+          setSelectedSegment={setSelectedSegment}
+          selectedSegment={selectedSegment}
+          allSegments={graphData}
+          setBreakTimer={setBreakTimer}
+        />
+      </Box>
+    </TabContent>
   )
 }
 

--- a/src/components/screen-time/index.test.js
+++ b/src/components/screen-time/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable import-order-alphabetical/order */
 import React from 'react'
 import { create } from 'react-test-renderer'
 import { ScreenTime } from '.'

--- a/src/components/screen-time/index.test.js
+++ b/src/components/screen-time/index.test.js
@@ -4,8 +4,17 @@ import { ScreenTime } from '.'
 
 const stampURLData = time => ({ time, breakTimer: {} })
 
+jest.mock('../../hooks/use-extension')
+jest.mock('@mujo/plugins')
+const { Tab } = require('@mujo/plugins')
+const { useExtension } = require('../../hooks/use-extension')
+
+beforeEach(() => {
+  Tab.mockImplementation(({ children }) => <>{children}</>)
+})
+
 test('ScreenTime should match snapshot', () => {
-  const mockData = {
+  const siteTimesAndTimers = {
     'https://foo.com': stampURLData(28619.509999931324),
     'https://mail.bar.com': stampURLData(30.375000031664968),
     'https://web.baz.com': stampURLData(21890.895000076387),
@@ -13,16 +22,17 @@ test('ScreenTime should match snapshot', () => {
     'https://developer.qux.com': stampURLData(2462.855000048876),
     'https://my.foobar.com': stampURLData(1728.3849999657832),
   }
-  const tree = create(<ScreenTime data={mockData} />).toJSON()
+  useExtension.mockReturnValue({ siteTimesAndTimers, screenTime: {} })
+  const tree = create(<ScreenTime />).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
 test('ScreenTime should match snapshot with a selected segment', () => {
-  const mockData = {
+  const siteTimesAndTimers = {
     'https://foo.com': stampURLData(6619.509999931324),
     'https://mail.bar.com': stampURLData(3230.375000031664968),
   }
-  const mockSelectedSegment = {
+  const selectedSegment = {
     label: 'foo.com',
     data: {
       originURL: 'https://foo.com',
@@ -31,29 +41,29 @@ test('ScreenTime should match snapshot with a selected segment', () => {
     },
     urls: ['https://foo.com'],
   }
-  const tree = create(
-    <ScreenTime
-      data={mockData}
-      selectedSegment={mockSelectedSegment}
-    />
-  ).toJSON()
+  useExtension.mockReturnValue({
+    siteTimesAndTimers,
+    selectedSegment,
+    screenTime: {},
+  })
+  const tree = create(<ScreenTime />).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
 test('ScreenTime should match snapshot with a grouped selected segment', () => {
-  const mockData = {
+  const siteTimesAndTimers = {
     'https://foo.com': stampURLData(6619.509999931324),
     'https://mail.bar.com': stampURLData(3230.375000031664968),
   }
-  const mockSelectedSegment = {
+  const selectedSegment = {
     label: 'qux',
     urls: ['https://foo.com', 'https://main.bar.com'],
   }
-  const tree = create(
-    <ScreenTime
-      data={mockData}
-      selectedSegment={mockSelectedSegment}
-    />
-  ).toJSON()
+  useExtension.mockReturnValue({
+    siteTimesAndTimers,
+    selectedSegment,
+    screenTime: {},
+  })
+  const tree = create(<ScreenTime />).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/screen-time/not-enough-data.js
+++ b/src/components/screen-time/not-enough-data.js
@@ -14,9 +14,10 @@ export const NotEnoughData = props => {
   const { t } = useTranslation(TRANSLATION_FILE)
   return (
     <Box>
-      <svg
-        width="600"
-        height="250"
+      <Box
+        Component="svg"
+        width="600px"
+        height="250px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <Box
@@ -80,7 +81,7 @@ export const NotEnoughData = props => {
           cy="126"
           r="15"
         />
-      </svg>
+      </Box>
       <BodyS>{t('keep-exploring')}</BodyS>
     </Box>
   )

--- a/src/components/screen-time/not-enough-data.js
+++ b/src/components/screen-time/not-enough-data.js
@@ -14,8 +14,7 @@ export const NotEnoughData = props => {
   const { t } = useTranslation(TRANSLATION_FILE)
   return (
     <Box>
-      <Box
-        Component="svg"
+      <svg
         width="600"
         height="250"
         xmlns="http://www.w3.org/2000/svg"
@@ -81,7 +80,7 @@ export const NotEnoughData = props => {
           cy="126"
           r="15"
         />
-      </Box>
+      </svg>
       <BodyS>{t('keep-exploring')}</BodyS>
     </Box>
   )

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -1,0 +1,50 @@
+import { Box } from '@mujo/box'
+import { Ingress, IngressTarget } from '@mujo/ingress'
+import React, { useEffect } from 'react'
+import { useExtension } from '../../hooks/use-extension'
+
+const TABS_TARGET = 'tabs'
+
+export const Tab = ({ label, selected, onClick }) => (
+  <Box
+    paddingLeft="m"
+    paddingRight="m"
+    whiteSpace="nowrap"
+    onClick={onClick}
+  >
+    {label}
+  </Box>
+)
+
+export const TabContent = ({ name, children }) => {
+  const { pushTab, removeTab, currentTab } = useExtension()
+
+  useEffect(() => {
+    pushTab(name)
+    return removeTab(name)
+  }, [name])
+
+  if (name !== currentTab) return null
+  return <Ingress target={TABS_TARGET}>{children}</Ingress>
+}
+
+export const TabTarget = () => <IngressTarget id={TABS_TARGET} />
+
+export const Tabs = () => {
+  const { tabs, currentTab, selectTab } = useExtension()
+
+  return (
+    <Box display="flex" direction="row">
+      {tabs.map(name => (
+        <Tab
+          key={name}
+          label={name}
+          selected={name === currentTab}
+          onClick={() => {
+            selectTab(name)
+          }}
+        />
+      ))}
+    </Box>
+  )
+}

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -1,9 +1,8 @@
 import { Box } from '@mujo/box'
-import { Ingress, IngressTarget } from '@mujo/ingress'
-import React, { useEffect } from 'react'
+import { IngressTarget } from '@mujo/ingress'
+import React from 'react'
+import { TABS_TARGET } from '../../constants'
 import { useExtension } from '../../hooks/use-extension'
-
-const TABS_TARGET = 'tabs'
 
 export const Tab = ({ label, selected, onClick }) => (
   <Box
@@ -16,19 +15,7 @@ export const Tab = ({ label, selected, onClick }) => (
   </Box>
 )
 
-export const TabContent = ({ name, children }) => {
-  const { pushTab, removeTab, currentTab } = useExtension()
-
-  useEffect(() => {
-    pushTab(name)
-    return removeTab(name)
-  }, [name])
-
-  if (name !== currentTab) return null
-  return <Ingress target={TABS_TARGET}>{children}</Ingress>
-}
-
-export const TabTarget = () => <IngressTarget id={TABS_TARGET} />
+export const TabsTarget = () => <IngressTarget id={TABS_TARGET} />
 
 export const Tabs = () => {
   const { tabs, currentTab, selectTab } = useExtension()

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -1,21 +1,7 @@
 import { Box } from '@mujo/box'
-import { IngressTarget } from '@mujo/ingress'
 import React from 'react'
-import { TABS_TARGET } from '../../constants'
 import { useExtension } from '../../hooks/use-extension'
-
-export const Tab = ({ label, selected, onClick }) => (
-  <Box
-    paddingLeft="m"
-    paddingRight="m"
-    whiteSpace="nowrap"
-    onClick={onClick}
-  >
-    {label}
-  </Box>
-)
-
-export const TabsTarget = () => <IngressTarget id={TABS_TARGET} />
+import { Tab } from './tab'
 
 export const Tabs = () => {
   const { tabs, currentTab, selectTab } = useExtension()

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -1,0 +1,43 @@
+import { Box } from '@mujo/box'
+import React, { useState } from 'react'
+import { useTheme } from '../../hooks/use-theme'
+import { BodyS } from '../fonts'
+
+export const Tab = ({ label, selected, onClick }) => {
+  const [hovered, setHovered] = useState(false)
+  const { highlight } = useTheme()
+  const yPosition = hovered ? 4 : 8
+  const css = {
+    marginLeft: '-8px',
+    marginBottom: '-8px',
+    left: '50%',
+    bottom: 0,
+    transition: 'transform 0.2s ease-in-out',
+    transform: `translateY(${selected ? 0 : yPosition}px) scale(${
+      selected ? 1 : 0.8
+    })`,
+  }
+  return (
+    <Box
+      position="relative"
+      paddingLeft="m"
+      paddingRight="m"
+      whiteSpace="nowrap"
+      overflow="hidden"
+      cursor="pointer"
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <Box
+        position="absolute"
+        height="m"
+        width="m"
+        borderRadius="m"
+        css={css}
+        backgroundColor={highlight}
+      />
+      <BodyS>{label}</BodyS>
+    </Box>
+  )
+}

--- a/src/components/top-sites/index.js
+++ b/src/components/top-sites/index.js
@@ -1,5 +1,6 @@
 import { css } from '@emotion/core'
 import { Box } from '@mujo/box'
+import { Tab } from '@mujo/plugins'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TRANSLATION_FILE } from '../../constants'
@@ -7,7 +8,6 @@ import { useExtension } from '../../hooks/use-extension'
 import { useTheme } from '../../hooks/use-theme'
 import { FavRows } from '../fav-rows'
 import { HeaderS } from '../fonts'
-import { TabContent } from '../tabs'
 import { ToolTip } from '../tool-tip'
 
 const siteWrapper = css({
@@ -27,7 +27,7 @@ export const TopSites = () => {
   const { t } = useTranslation(TRANSLATION_FILE)
 
   return (
-    <TabContent name="Top Sites">
+    <Tab name="Top Sites">
       <Box
         display="flex"
         flex={1}
@@ -58,6 +58,6 @@ export const TopSites = () => {
           />
         ) : null}
       </Box>
-    </TabContent>
+    </Tab>
   )
 }

--- a/src/components/top-sites/index.js
+++ b/src/components/top-sites/index.js
@@ -3,9 +3,11 @@ import { Box } from '@mujo/box'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TRANSLATION_FILE } from '../../constants'
+import { useExtension } from '../../hooks/use-extension'
 import { useTheme } from '../../hooks/use-theme'
 import { FavRows } from '../fav-rows'
 import { HeaderS } from '../fonts'
+import { TabContent } from '../tabs'
 import { ToolTip } from '../tool-tip'
 
 const siteWrapper = css({
@@ -18,36 +20,44 @@ const siteWrapper = css({
   },
 })
 
-export const TopSites = ({ topSites, updateSitesUsed }) => {
+export const TopSites = () => {
+  const { topSites, updateSitesUsed } = useExtension()
   const [toolTipOpen, setToolTipOpen] = useState(false)
   const { foreground } = useTheme()
   const { t } = useTranslation(TRANSLATION_FILE)
 
   return (
-    <Box
-      display="flex"
-      flex={1}
-      direction="column"
-      justifyContent="center"
-      alignItems="center"
-      textAlign="center"
-      position="relative"
-      layer="1"
-      {...siteWrapper}
-    >
-      <HeaderS
+    <TabContent name="Top Sites">
+      <Box
+        display="flex"
+        flex={1}
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        textAlign="center"
         position="relative"
-        cursor="pointer"
-        color={foreground}
-        onMouseLeave={() => setToolTipOpen(false)}
-        onMouseEnter={() => setToolTipOpen(true)}
+        layer="1"
+        {...siteWrapper}
       >
-        {t('top-sites')}
-        <ToolTip isOpen={toolTipOpen}>{t('top-sites-usage')}</ToolTip>
-      </HeaderS>
-      {topSites.length ? (
-        <FavRows items={topSites} updateSitesUsed={updateSitesUsed} />
-      ) : null}
-    </Box>
+        <HeaderS
+          position="relative"
+          cursor="pointer"
+          color={foreground}
+          onMouseLeave={() => setToolTipOpen(false)}
+          onMouseEnter={() => setToolTipOpen(true)}
+        >
+          {t('top-sites')}
+          <ToolTip isOpen={toolTipOpen}>
+            {t('top-sites-usage')}
+          </ToolTip>
+        </HeaderS>
+        {topSites.length ? (
+          <FavRows
+            items={topSites}
+            updateSitesUsed={updateSitesUsed}
+          />
+        ) : null}
+      </Box>
+    </TabContent>
   )
 }

--- a/src/components/top-sites/index.js
+++ b/src/components/top-sites/index.js
@@ -27,7 +27,7 @@ export const TopSites = () => {
   const { t } = useTranslation(TRANSLATION_FILE)
 
   return (
-    <Tab name="Top Sites">
+    <Tab name={t('top-sites')}>
       <Box
         display="flex"
         flex={1}

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,6 +23,7 @@ export const MAX_ACTIVITY_ROWS = 40000
 export const BREATH_MAX = 20
 export const BREATH_MIN = 5
 export const TRANSLATION_FILE = 'translation'
+export const TABS_TARGET = 'tabs'
 
 // ALARMS
 export const ALARM_KEY = 'MINDFUL_ALARM' // also storage key

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,6 +49,7 @@ export const LAST_ACTIVE_KEY = 'LAST_ACTIVE_KEY'
 export const ACTIVITY_NUMBER_KEY = 'ACTIVITY_NUMBER_KEY'
 export const PREDICTED_BREAK_TIMES = 'PREDICTED_BREAK_TIMES'
 export const BREATH_AMOUNT_KEY = 'BREATH_AMOUNT'
+export const CURRENT_TAB_KEY = 'CURRENT_TAB'
 
 // Actions
 export const NEW_TAB_CONNECTION = 'New Connection'

--- a/src/e2e.test.js
+++ b/src/e2e.test.js
@@ -7,7 +7,7 @@ import {
 } from './constants'
 import { wait } from './lib/async-helpers'
 
-const TEST_TIMEOUT = 10000 // extend test timeout sinces its E2E
+const TEST_TIMEOUT = 20000 // extend test timeout sinces its E2E
 
 let browser
 let page

--- a/src/hooks/use-extension/index.js
+++ b/src/hooks/use-extension/index.js
@@ -12,6 +12,7 @@ import {
   APP_READY_KEY,
   SCREEN_TIME_PERMISSIONS,
   TRANSLATION_FILE,
+  CURRENT_TAB_KEY,
 } from '../../constants'
 import { toSiteInfo } from '../../lib/aggregation'
 import { message } from '../../lib/extension'
@@ -36,7 +37,7 @@ export const ExtensionProvider = props => {
   const [playerIsOpen, setPlayerIsOpen] = useState(false)
   const [selectedSegment, setSelectedSegment] = useState(null)
   const [upsellModal, setUpsellModal] = useState(null)
-  const tabInterface = useTabs()
+  const tabInterface = useTabs(CURRENT_TAB_KEY)
   const {
     alarmEnabled,
     setAlarmEnabled,

--- a/src/hooks/use-extension/index.js
+++ b/src/hooks/use-extension/index.js
@@ -1,3 +1,4 @@
+import { IngressProvider } from '@mujo/ingress'
 import React, {
   useEffect,
   useState,
@@ -21,6 +22,7 @@ import { decorateSelectedSegment, mapTopSites } from './transforms'
 import { useBreaktimerCallback } from './use-breaktimer-callback'
 import { useDeeplink } from './use-deeplink'
 import { useModel } from './use-model'
+import { useTabs } from './use-tabs'
 import { useTopsitesAPI } from './use-topsites-api'
 
 const context = React.createContext()
@@ -34,6 +36,7 @@ export const ExtensionProvider = props => {
   const [playerIsOpen, setPlayerIsOpen] = useState(false)
   const [selectedSegment, setSelectedSegment] = useState(null)
   const [upsellModal, setUpsellModal] = useState(null)
+  const tabInterface = useTabs()
   const {
     alarmEnabled,
     setAlarmEnabled,
@@ -159,9 +162,10 @@ export const ExtensionProvider = props => {
         setPlayerIsOpen,
         setUpsellModal,
         updateBreakTimers,
+        ...tabInterface,
       }}
     >
-      {props.children}
+      <IngressProvider>{props.children}</IngressProvider>
     </Provider>
   )
 }

--- a/src/hooks/use-extension/use-tabs.js
+++ b/src/hooks/use-extension/use-tabs.js
@@ -1,0 +1,74 @@
+import { useCallback, useState, useReducer } from 'react'
+
+const Actions = {
+  add: 'add',
+  remove: 'remove',
+}
+
+const tabsReducer = (state, action) => {
+  switch (action.type) {
+    case Actions.add:
+      return [...state, action.name]
+    case Actions.remove: {
+      const index = state.findIndex(action.name)
+      return [...state.slice(0, index), ...state.slice(index + 1)]
+    }
+    default:
+      return state
+  }
+}
+
+export const useTabs = () => {
+  const [tabs, dispatch] = useReducer(tabsReducer, [])
+  const [currentTab, setCurrentTab] = useState(null)
+
+  const pushTab = useCallback(
+    name => {
+      const exist = !!tabs.find(tab => tab === name)
+      if (exist) {
+        console.warn(
+          `Attempted to push a tab "${name}" that already exist`
+        )
+        return
+      }
+      dispatch({ type: Actions.add, name })
+      if (!currentTab) {
+        setCurrentTab(name)
+      }
+    },
+    [tabs, dispatch, currentTab, setCurrentTab]
+  )
+
+  const removeTab = useCallback(
+    name => {
+      const index = tabs.findIndex(tab => tab === name)
+      if (index === -1) {
+        console.warn(
+          `Attempted to remove a tab "${name}" that does not exist`
+        )
+        return
+      }
+      // TODO: seems like we might have a case where we will
+      // not have a current tab
+      dispatch({ type: Actions.remove, name })
+    },
+    [tabs, dispatch]
+  )
+
+  const selectTab = useCallback(
+    name => {
+      if (name === currentTab) return
+      const exist = !!tabs.find(tab => tab === name)
+      if (!exist) {
+        console.warn(
+          `Attempted to select tab "${name}" that does not exist`
+        )
+        return
+      }
+      setCurrentTab(name)
+    },
+    [tabs, setCurrentTab, currentTab]
+  )
+
+  return { tabs, currentTab, pushTab, selectTab, removeTab }
+}

--- a/src/hooks/use-extension/use-tabs.js
+++ b/src/hooks/use-extension/use-tabs.js
@@ -1,4 +1,5 @@
-import { useCallback, useReducer } from 'react'
+import { useCallback, useReducer, useEffect } from 'react'
+import { useStorage } from '../use-storage'
 
 const Actions = {
   add: 'add',
@@ -31,9 +32,10 @@ const tabsReducer = (state, action) => {
   }
 }
 
-export const useTabs = () => {
+export const useTabs = key => {
+  const [persistedTab, setPersistedTab, { pending }] = useStorage(key)
   const [{ tabs, currentTab }, dispatch] = useReducer(tabsReducer, {
-    currentTab: null,
+    currentTab: persistedTab,
     tabs: [],
   })
 
@@ -81,6 +83,20 @@ export const useTabs = () => {
     },
     [tabs, dispatch, currentTab]
   )
+
+  // updates selected tab from storage
+  useEffect(() => {
+    if (currentTab !== persistedTab && !pending) {
+      selectTab(persistedTab)
+    }
+  }, [persistedTab, pending])
+
+  // updates storage from selected tab
+  useEffect(() => {
+    if (currentTab !== persistedTab && !pending) {
+      setPersistedTab(currentTab)
+    }
+  }, [currentTab])
 
   return { tabs, currentTab, pushTab, selectTab, removeTab }
 }

--- a/src/hooks/use-extension/use-tabs.js
+++ b/src/hooks/use-extension/use-tabs.js
@@ -1,17 +1,30 @@
-import { useCallback, useState, useReducer } from 'react'
+import { useCallback, useReducer } from 'react'
 
 const Actions = {
   add: 'add',
   remove: 'remove',
+  setCurrent: 'setCurrent',
 }
 
 const tabsReducer = (state, action) => {
   switch (action.type) {
     case Actions.add:
-      return [...state, action.name]
+      return {
+        currentTab: state.currentTab || action.name,
+        tabs: [...state.tabs, action.name],
+      }
     case Actions.remove: {
       const index = state.findIndex(action.name)
-      return [...state.slice(0, index), ...state.slice(index + 1)]
+      return {
+        ...state,
+        tabs: [
+          ...state.tabs.slice(0, index),
+          ...state.tabs.slice(index + 1),
+        ],
+      }
+    }
+    case Actions.setCurrent: {
+      return { ...state, currentTab: action.name }
     }
     default:
       return state
@@ -19,8 +32,10 @@ const tabsReducer = (state, action) => {
 }
 
 export const useTabs = () => {
-  const [tabs, dispatch] = useReducer(tabsReducer, [])
-  const [currentTab, setCurrentTab] = useState(null)
+  const [{ tabs, currentTab }, dispatch] = useReducer(tabsReducer, {
+    currentTab: null,
+    tabs: [],
+  })
 
   const pushTab = useCallback(
     name => {
@@ -32,11 +47,8 @@ export const useTabs = () => {
         return
       }
       dispatch({ type: Actions.add, name })
-      if (!currentTab) {
-        setCurrentTab(name)
-      }
     },
-    [tabs, dispatch, currentTab, setCurrentTab]
+    [tabs, dispatch]
   )
 
   const removeTab = useCallback(
@@ -65,9 +77,9 @@ export const useTabs = () => {
         )
         return
       }
-      setCurrentTab(name)
+      dispatch({ type: Actions.setCurrent, name })
     },
-    [tabs, setCurrentTab, currentTab]
+    [tabs, dispatch, currentTab]
   )
 
   return { tabs, currentTab, pushTab, selectTab, removeTab }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { useColorScheme } from 'use-color-scheme'
 import App from './app'
 import { ErrorBox } from './components/error-box'
 import { Font } from './components/fonts'
+import { NTPPluginProvider } from './components/plugin-provider'
 import { ExtensionProvider } from './hooks/use-extension'
 import { SubscriptionProvider } from './hooks/use-subscription'
 import { ColorThemeProvider } from './hooks/use-theme'
@@ -17,9 +18,11 @@ const NewHomePage = () => {
       <Font />
       <SubscriptionProvider>
         <ExtensionProvider shouldRegisterApp={true}>
-          <ColorThemeProvider value={scheme}>
-            <App />
-          </ColorThemeProvider>
+          <NTPPluginProvider>
+            <ColorThemeProvider value={scheme}>
+              <App />
+            </ColorThemeProvider>
+          </NTPPluginProvider>
         </ExtensionProvider>
       </SubscriptionProvider>
     </ErrorBox>

--- a/src/model.js
+++ b/src/model.js
@@ -12,6 +12,7 @@ import {
   PREDICTED_BREAK_TIMES,
   ID_KEY,
   BREATH_AMOUNT_KEY,
+  CURRENT_TAB_KEY,
 } from './constants'
 
 export default {
@@ -27,4 +28,5 @@ export default {
   [PREDICTED_BREAK_TIMES]: { type: Object, defaultValue: [] },
   [ID_KEY]: { type: String, default: null },
   [BREATH_AMOUNT_KEY]: { type: Number, defaultValue: 5 },
+  [CURRENT_TAB_KEY]: { type: String, defaultValue: null },
 }

--- a/src/styles/utils.js
+++ b/src/styles/utils.js
@@ -55,9 +55,11 @@ const sizes = {
   xxl: '48px',
   // overrides
   '100%': '100%',
-  '500px': '500px',
-  '300px': '300px',
   '100px': '100px',
+  '250px': '250px',
+  '300px': '300px',
+  '500px': '500px',
+  '600px': '600px',
 }
 
 export const width = makeStyles('width', sizes)

--- a/src/styles/utils.js
+++ b/src/styles/utils.js
@@ -60,6 +60,10 @@ const radius = {
   l: '24px',
 }
 
+// This might need to be revised
+export const width = makeStyles('width', radius)
+export const height = makeStyles('height', radius)
+
 export const borderRadius = makeStyles('borderRadius', radius)
 export const borderTopLeftRadius = makeStyles(
   'borderTopLeftRadius',

--- a/src/styles/utils.js
+++ b/src/styles/utils.js
@@ -24,13 +24,6 @@ export const fill = makeStyles('fill', colors)
 export const stroke = makeStyles('stroke', colors)
 export const outlineColor = makeStyles('outlineColor', colors)
 
-export const maxWidth = {
-  '100%': css({ maxWidth: '100%' }),
-  '500px': css({ maxWidth: '500px' }),
-  '300px': css({ maxWidth: '300px' }),
-  '100px': css({ maxWidth: '100px' }),
-}
-
 export const textOverflow = {
   ellipsis: css({ textOverflow: 'ellipsis' }),
   clip: css({ textOverflow: 'clip' }),
@@ -53,33 +46,41 @@ export const position = {
 
 export const display = { table: css({ display: 'table' }) }
 
-const radius = {
+const sizes = {
   xs: '4px',
   s: '8px',
   m: '16px',
   l: '24px',
+  xl: '32px',
+  xxl: '48px',
+  // overrides
+  '100%': '100%',
+  '500px': '500px',
+  '300px': '300px',
+  '100px': '100px',
 }
 
-// This might need to be revised
-export const width = makeStyles('width', radius)
-export const height = makeStyles('height', radius)
+export const width = makeStyles('width', sizes)
+export const maxWidth = makeStyles('maxWidth', sizes)
+export const height = makeStyles('height', sizes)
+export const maxHeight = makeStyles('maxHeight', sizes)
 
-export const borderRadius = makeStyles('borderRadius', radius)
+export const borderRadius = makeStyles('borderRadius', sizes)
 export const borderTopLeftRadius = makeStyles(
   'borderTopLeftRadius',
-  radius
+  sizes
 )
 export const borderBottomLeftRadius = makeStyles(
   'borderBottomLeftRadius',
-  radius
+  sizes
 )
 export const borderTopRightRadius = makeStyles(
   'borderTopRightRadius',
-  radius
+  sizes
 )
 export const borderBottomRightRadius = makeStyles(
   'borderBottomRightRadius',
-  radius
+  sizes
 )
 
 export const layer = {
@@ -92,3 +93,4 @@ export const layer = {
 const flexValues = { flexEnd: 'flex-end', flexStart: 'flex-start' }
 export const justifyContent = makeStyles('justifyContent', flexValues)
 export const alignItems = makeStyles('alignItems', flexValues)
+export const flexWrap = { wrap: css({ flexWrap: 'wrap' }) }


### PR DESCRIPTION
## Description

This PR is adding in the new tabbing system for Mujo. This is going to help with decoupling the tab views from the top-level container and start allowing tabs and data to live in plugins. In this PR you can start to see that pattern starting to take form.

<img width="379" alt="Screen Shot 2019-09-12 at 12 09 39 AM" src="https://user-images.githubusercontent.com/578259/64761738-a4498800-d4f1-11e9-9495-4be2b0aa6b8e.png">

## Details

With this implementation, we introduced a hook to manage the tabs state and hooked that into the extension hook. This allows us to `push` and `remove` the tabs in the context. These tabs are simply a string of the tab name. 

> This pattern is going to be similar to what we need to do with settings.

Then we now are using [@mujo-code/ingress](https://github.com/mujo-code/ingress) to allow the tabs to be placed anywhere ( eventually a plugin ) and render the content into the correct location. Please check out the repo for more details.

## TODO

- [x] Split apart the tab/index file to individual components.
- [x] add-in tab name translation string
- [x] fix and add test for tabs
- [x] cleanup the design and active states
- [x] fix weird flash bug with top sites
- [x] persistent storage for currentTab